### PR TITLE
feat: added filters (no backend)

### DIFF
--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -41,6 +41,7 @@ import DeleteInstanceModal from './DeleteInstanceModal';
 import InstanceDetailsDrawer from './InstanceDetailsDrawer';
 import { getDateTime } from '../../utils/date';
 import Status from '../../components/Status';
+import InstancesToolbarSearchFilter from './InstancesToolbarSearchFilter';
 
 /**
  * A smart component that handles all the api calls and data needed by the dumb components.
@@ -52,6 +53,7 @@ import Status from '../../components/Status';
 function InstancesPage() {
   const history = useHistory();
   const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+  const [filters, setFilters] = useState({});
   const { data, isFetching } = useInstances({ query: { page, size: perPage } });
   const createInstance = useCreateInstance();
   const deleteInstance = useDeleteInstance();
@@ -96,6 +98,10 @@ function InstancesPage() {
     setViewingInstance(null);
   }
 
+  function onClearFilters() {
+    setFilters({});
+  }
+
   if (isFetching) {
     return (
       <Bullseye>
@@ -133,8 +139,12 @@ function InstancesPage() {
             </EmptyState>
           ) : (
             <>
-              <Toolbar>
+              <Toolbar clearAllFilters={onClearFilters}>
                 <ToolbarContent>
+                  <InstancesToolbarSearchFilter
+                    filters={filters}
+                    setFilters={setFilters}
+                  />
                   <ToolbarItem>
                     <Button
                       variant="primary"

--- a/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
+++ b/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
@@ -27,19 +27,13 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
 
   // TODO: Extract into separate utils file to be reused in other cases
   function onDeleteChip(type = '', id = '') {
-    if (type) {
-      setFilters((prevFilters) => {
-        const newFilters = { ...prevFilters };
-        newFilters[type.toLowerCase()] = newFilters[type.toLowerCase()].filter(
-          (s) => s !== id
-        );
-        return newFilters;
-      });
-    } else {
-      setFilters({
-        region: [],
-      });
-    }
+    setFilters((prevFilters) => {
+      const newFilters = { ...prevFilters };
+      newFilters[type.toLowerCase()] = newFilters[type.toLowerCase()].filter(
+        (s) => s !== id
+      );
+      return newFilters;
+    });
   }
 
   // TODO: Extract into separate utils file to be reused in other cases

--- a/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
+++ b/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
@@ -1,0 +1,230 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ToolbarToggleGroup,
+  ToolbarGroup,
+  ToolbarFilter,
+  SelectVariant,
+  SelectOption,
+  Select,
+  ToolbarItem,
+  InputGroup,
+  TextInput,
+  Button,
+} from '@patternfly/react-core';
+import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+import SelectSingle from '../../components/SelectSingle';
+
+function InstancesToolbarSearchFilter({ filters, setFilters }) {
+  const [selectedFilter, setSelectedFilter] = useState('Name');
+  // local state for input values
+  const [inputName, setInputName] = useState('');
+  const [inputOwner, setInputOwner] = useState('');
+  // local state for Select isExpanded values
+  // @TODO: We can refactor the SelectSingle component to be more reusable for the usecase in this component as well. Then we don't need to keep this state here.
+  const [isRegionExpanded, setIsRegionExpanded] = useState(false);
+  const [isStatusExpanded, setIsStatusExpanded] = useState(false);
+
+  // TODO: Extract into separate utils file to be reused in other cases
+  function onDeleteChip(type = '', id = '') {
+    if (type) {
+      setFilters((prevFilters) => {
+        const newFilters = { ...prevFilters };
+        newFilters[type.toLowerCase()] = newFilters[type.toLowerCase()].filter(
+          (s) => s !== id
+        );
+        return newFilters;
+      });
+    } else {
+      setFilters({
+        region: [],
+      });
+    }
+  }
+
+  // TODO: Extract into separate utils file to be reused in other cases
+  function onDeleteChipGroup(type) {
+    setFilters((prevFilters) => {
+      const newFilters = { ...prevFilters };
+      newFilters[type.toLowerCase()] = [];
+      return newFilters;
+    });
+  }
+
+  // TODO: Extract into separate utils file to be reused in other cases
+  function onSelect(type, event, selection) {
+    const checked = event.target.checked;
+    setFilters((prevFilters) => {
+      const prevSelections = prevFilters[type] || [];
+      return {
+        ...prevFilters,
+        [type]: checked
+          ? [...prevSelections, selection]
+          : prevSelections.filter((value) => value !== selection),
+      };
+    });
+  }
+
+  function onRegionSelect(event, selection) {
+    onSelect('region', event, selection);
+  }
+
+  function onStatusSelect(event, selection) {
+    onSelect('status', event, selection);
+  }
+
+  return (
+    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+      <ToolbarGroup variant="filter-group">
+        <ToolbarItem>
+          <SelectSingle
+            id="region"
+            value={selectedFilter}
+            handleSelect={(_, selection) => {
+              setSelectedFilter(selection);
+            }}
+          >
+            <SelectOption value="Name">Name</SelectOption>
+            <SelectOption value="Region">Region</SelectOption>
+            <SelectOption value="Owner">Owner</SelectOption>
+            <SelectOption value="Status">Status</SelectOption>
+          </SelectSingle>
+        </ToolbarItem>
+        <ToolbarFilter
+          chips={filters.name}
+          deleteChip={onDeleteChip}
+          deleteChipGroup={onDeleteChipGroup}
+          categoryName="Name"
+          className={selectedFilter !== 'Name' && 'pf-u-hidden'}
+        >
+          <ToolbarItem>
+            <InputGroup>
+              <TextInput
+                id="filterName"
+                type="text"
+                aria-label="Name"
+                placeholder="Filter by name"
+                value={inputName}
+                onChange={(value) => setInputName(value)}
+              />
+              <Button
+                variant="control"
+                aria-label="Search Name"
+                onClick={() => {
+                  if (!inputName) return;
+                  setFilters((prevFilters) => {
+                    const newFilters = { ...prevFilters };
+                    newFilters.name = [inputName];
+                    console.log(newFilters);
+                    return newFilters;
+                  });
+                }}
+              >
+                <SearchIcon />
+              </Button>
+            </InputGroup>
+          </ToolbarItem>
+        </ToolbarFilter>
+        <ToolbarFilter
+          chips={filters.region}
+          deleteChip={onDeleteChip}
+          deleteChipGroup={onDeleteChipGroup}
+          categoryName="Region"
+          className={selectedFilter !== 'Region' && 'pf-u-hidden'}
+        >
+          <ToolbarItem>
+            <Select
+              variant={SelectVariant.checkbox}
+              aria-label="Region"
+              onToggle={setIsRegionExpanded}
+              onSelect={onRegionSelect}
+              selections={filters.region}
+              isOpen={isRegionExpanded}
+              placeholderText="Filter by region"
+            >
+              <SelectOption value="US-East, N. Virginia">
+                US-East, N. Virginia
+              </SelectOption>
+              <SelectOption value="EU-Ireland">EU-Ireland</SelectOption>
+            </Select>
+          </ToolbarItem>
+        </ToolbarFilter>
+        <ToolbarFilter
+          chips={filters.owner}
+          deleteChip={onDeleteChip}
+          deleteChipGroup={onDeleteChipGroup}
+          categoryName="Owner"
+          className={selectedFilter !== 'Owner' && 'pf-u-hidden'}
+        >
+          <ToolbarItem>
+            <InputGroup>
+              <TextInput
+                id="filterOwner"
+                type="text"
+                aria-label="Owner"
+                placeholder="Filter by owner"
+                value={inputOwner}
+                onChange={(value) => setInputOwner(value)}
+              />
+              <Button
+                variant="control"
+                aria-label="Search Owner"
+                onClick={() => {
+                  if (!inputOwner) return;
+                  setFilters((prevFilters) => {
+                    const newFilters = { ...prevFilters };
+                    newFilters.owner = [inputOwner];
+                    return newFilters;
+                  });
+                }}
+              >
+                <SearchIcon />
+              </Button>
+            </InputGroup>
+          </ToolbarItem>
+        </ToolbarFilter>
+        <ToolbarFilter
+          chips={filters.status}
+          deleteChip={onDeleteChip}
+          deleteChipGroup={onDeleteChipGroup}
+          categoryName="Status"
+          className={selectedFilter !== 'Status' && 'pf-u-hidden'}
+        >
+          <ToolbarItem>
+            <Select
+              variant={SelectVariant.checkbox}
+              aria-label="Status"
+              onToggle={setIsStatusExpanded}
+              onSelect={onStatusSelect}
+              selections={filters.status}
+              isOpen={isStatusExpanded}
+              placeholderText="Filter by status"
+            >
+              <SelectOption value="Ready">Ready</SelectOption>
+              <SelectOption value="Failed">Failed</SelectOption>
+              <SelectOption value="Creation pending">
+                Creation pending
+              </SelectOption>
+              <SelectOption value="Creation in progress">
+                Creation in progress
+              </SelectOption>
+              <SelectOption value="Deleting">Deleting</SelectOption>
+            </Select>
+          </ToolbarItem>
+        </ToolbarFilter>
+      </ToolbarGroup>
+    </ToolbarToggleGroup>
+  );
+}
+
+InstancesToolbarSearchFilter.propTypes = {
+  filters: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    region: PropTypes.string.isRequired,
+    owner: PropTypes.string.isRequired,
+    status: PropTypes.string.isRequired,
+  }),
+  setFilters: PropTypes.func.isRequired,
+};
+
+export default InstancesToolbarSearchFilter;


### PR DESCRIPTION
## Details
The following adds toolbar filters to filter the data in the tables. We can filter by the following:
1. Name
2. Region `US-East, N. Virginia` and `EU-Ireland`
3. Owner 
4. Status - `Ready`, `Failed`, `Creation pending`, `Creation in progress`, and `Deleting`

## Screenshots

![Screen Shot 2022-05-10 at 3 06 08 PM](https://user-images.githubusercontent.com/4805485/167730172-a723ef5d-fe8e-46cf-acb1-67115111f2df.png)
![Screen Shot 2022-05-10 at 3 06 17 PM](https://user-images.githubusercontent.com/4805485/167730177-47dfd8f3-42d6-4ebb-beac-a8354a62e3bf.png)
![Screen Shot 2022-05-10 at 3 06 44 PM](https://user-images.githubusercontent.com/4805485/167730182-d2b473c9-0a1f-4efd-a11f-af55d1745dab.png)
![Screen Shot 2022-05-10 at 3 06 54 PM](https://user-images.githubusercontent.com/4805485/167730184-c9f14020-e932-4cf3-8d8b-1effe4f126fb.png)
