### PR TITLE
fix: Update Proxy Settings and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ You should also set up the Red Hat squid proxy using [this guide](https://source
 
 1. ```npm install```
 
-2. ```npm run start:beta```
+**Note:**  that the next step will not work unless we mock the backend because the Fleet Manager API hasn't been integrated yet. The README will be updated once it works. You can follow the steps in the "Mocking" section to run a mock REST server for testing purposes for now.
 
-**Note:**  that this may not work as of right now. The README will be updated once it works. You can look at the "Mocking" section for an alternative way to run the UI for now.
+2. ```npm run start:beta```
 
 3. Open browser in URL listed in the terminal output
 
@@ -36,15 +36,11 @@ You should also set up the Red Hat squid proxy using [this guide](https://source
 
 ### Mocking
 
-In order to try mock data rather than real data from the Backend APIs, you can run the following commands in two separate terminals:
+In order to try mock data rather than real data from the Backend APIs, you can run the following command in a separate terminal:
 
 1. `npm run start:mock-server`
 
-This will run JSON Server, which is a nice tool for creating a fake REST API for prototyping and mocking
-
-2. `npm run start:mock`
-
-This will start the Webpack Dev Server but redirect the API calls to the Mock REST API instead of the real Backend API
+This will run JSON Server, which is a nice tool for creating a fake REST API for prototyping and mocking. Once that server is running, you can continue with the steps outlined in the "Getting Started" section
 
 
 ## Definitions

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -2,20 +2,12 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const commonPlugins = require('./plugins');
 
-let customProxy = process.env.BETA
-  ? [
-      {
-        context: ['/api'],
-        target: 'http://localhost:4000',
-      },
-    ]
-  : [
-      {
-        context: ['/api'],
-        target:
-          process.env.FLEET_MANAGER_API_ENDPOINT || 'http://localhost:8000',
-      },
-    ];
+let customProxy = [
+  {
+    context: ['/api'],
+    target: process.env.FLEET_MANAGER_API_ENDPOINT || 'http://localhost:8000',
+  },
+];
 
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),

--- a/mocks/db.server.js
+++ b/mocks/db.server.js
@@ -44,7 +44,7 @@ server.use(
 
 // Use default router
 server.use(router);
-server.listen(4000, () => {
+server.listen(8000, () => {
   console.log('JSON Server is running');
 });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "patch:hosts": "fec patch-etc-hosts",
     "start": "webpack serve --config config/dev.webpack.config.js",
     "start:beta": "NODE_OPTIONS='--max-http-header-size=100000' BETA=true npm start",
-    "start:mock": "NODE_OPTIONS='--max-http-header-size=100000' BETA=true USE_MOCK_DATA=true npm start",
     "start:mock-server": "NODE_OPTIONS='--max-http-header-size=100000' node mocks/db.server.js",
     "test": "jest",
     "verify": "npm-run-all build lint test"


### PR DESCRIPTION
Made a few updates for simplicity:

1. We will use the same PORT (8000) for the Mock API endpoint so we don't have to have to have a conditional to proxy between 4000 and 8000
3. I fixed the `customProxy` value. I'm not sure why we were using the `process.env.BETA` to determine where to proxy. It might have been a mistake. It should have been the environment variable related to whether we're mocking or not
4. Because of `(2)`, I thought the extra command `npm run start:mock` wasn't necessary anymore so I removed that
5. Because of `(3)`, I updated the README