### PR TITLE
feat: adding command to use prod env

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -2,11 +2,19 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const commonPlugins = require('./plugins');
 
+function getEnv() {
+  if (process.env.PROD) {
+    return process.env.BETA ? 'prod-beta' : 'prod-stable';
+  } else {
+    return process.env.BETA ? 'stage-beta' : 'stage-stable';
+  }
+}
+
 let customProxy = [
   {
     context: ['/api'],
     target: process.env.FLEET_MANAGER_API_ENDPOINT || 'http://localhost:8000',
-  },
+  }
 ];
 
 const { config: webpackConfig, plugins } = config({
@@ -17,7 +25,7 @@ const { config: webpackConfig, plugins } = config({
   appUrl: process.env.BETA
     ? '/beta/application-services/acs'
     : '/application-services/acs',
-  env: process.env.BETA ? 'stage-beta' : 'stage-stable',
+  env: getEnv(),
   customProxy,
 });
 plugins.push(...commonPlugins);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "nightly": "npm run deploy",
     "patch:hosts": "fec patch-etc-hosts",
     "start": "webpack serve --config config/dev.webpack.config.js",
+    "start:prod": "NODE_OPTIONS='--max-http-header-size=100000' PROD=true npm start",
     "start:beta": "NODE_OPTIONS='--max-http-header-size=100000' BETA=true npm start",
+    "start:prod:beta": "NODE_OPTIONS='--max-http-header-size=100000' PROD=true BETA=true npm start",
     "start:mock-server": "NODE_OPTIONS='--max-http-header-size=100000' node mocks/db.server.js",
     "test": "jest",
     "verify": "npm-run-all build lint test"


### PR DESCRIPTION
This PR adds the following new commands: 

```
npm run start:prod
npm run start:prod:beta
```

We can use these commands to run in prod (locally)