### PR TITLE
feat: renaming mock APIs based on the actual backend APIs

### DIFF
--- a/mocks/db.server.js
+++ b/mocks/db.server.js
@@ -1,7 +1,7 @@
 const uuid = require('uuid');
 const jsonServer = require('json-server');
 const server = jsonServer.create();
-const router = jsonServer.router({ dinosaurs: [] });
+const router = jsonServer.router({ centrals: [] });
 const middlewares = jsonServer.defaults();
 
 // Set default middlewares (logger, static, cors and no-cache)
@@ -12,23 +12,23 @@ server.use((req, res, next) => {
   if (req.method === 'POST') {
     const { region, cloud_provider, name, multi_az } = req.body;
     const newId = uuid.v4();
-    const newDinosaur = {
+    const newCentral = {
       id: newId,
-      kind: 'dinosaur',
-      href: '/api/dinosaurs_mgmt/v1/dinosaurs/' + newId,
+      kind: 'central',
+      href: '/api/rhacs/v1/centrals/' + newId,
       status: 'ready',
       cloud_provider,
       multi_az,
       region,
-      owner: 'api_dinosaur_service',
+      owner: 'api_rhacs_service',
       name,
-      host: name + '-' + newId + '.example.dinosaur.com',
+      host: name + '-' + newId + '.example.rhacs.com',
       created_at: '2020-10-05T12:51:24.053142Z',
       updated_at: '2020-10-05T12:56:36.362208Z',
       version: '2.6.0',
       instance_type: 'standard',
     };
-    req.body = newDinosaur;
+    req.body = newCentral;
   }
   // Continue to JSON Server router
   next();
@@ -37,8 +37,8 @@ server.use((req, res, next) => {
 // Add this before server.use(router)
 server.use(
   jsonServer.rewriter({
-    '/api/dinosaurs_mgmt/v1/dinosaurs\\?*': '/dinosaurs',
-    '/api/dinosaurs_mgmt/v1/dinosaurs/:id': '/dinosaurs/:id',
+    '/api/rhacs/v1/centrals\\?*': '/centrals',
+    '/api/rhacs/v1/centrals/:id': '/centrals/:id',
   })
 );
 
@@ -51,9 +51,9 @@ server.listen(4000, () => {
 // In this example, returned resources will be wrapped in a body property
 router.render = (req, res) => {
   console.log(res);
-  if (req.method === 'GET' && req.url === '/dinosaurs') {
+  if (req.method === 'GET' && req.url === '/centrals') {
     res.jsonp({
-      kind: 'DinosaurRequestList',
+      kind: 'CentralRequestList',
       page: '1',
       size: '20',
       total: res.locals.data.length,

--- a/src/hooks/apis/useCreateInstance.js
+++ b/src/hooks/apis/useCreateInstance.js
@@ -4,7 +4,7 @@ import apiRequest from '../../services/apiRequest';
 
 const postInstance = async (postData) => {
   const { data } = await apiRequest.post(
-    '/api/dinosaurs_mgmt/v1/dinosaurs?async=true',
+    '/api/rhacs/v1/centrals?async=true',
     postData
   );
   return data;

--- a/src/hooks/apis/useDeleteInstance.js
+++ b/src/hooks/apis/useDeleteInstance.js
@@ -4,7 +4,7 @@ import apiRequest from '../../services/apiRequest';
 
 const deleteInstance = async (instanceID) => {
   const { data } = await apiRequest.delete(
-    `/api/dinosaurs_mgmt/v1/dinosaurs/${instanceID}`
+    `/api/rhacs/v1/centrals/${instanceID}`
   );
   return data;
 };

--- a/src/hooks/apis/useInstance.js
+++ b/src/hooks/apis/useInstance.js
@@ -3,9 +3,7 @@ import { useQuery } from 'react-query';
 import apiRequest from '../../services/apiRequest';
 
 const getInstanceById = async (instanceId) => {
-  const { data } = await apiRequest.get(
-    `/api/dinosaurs_mgmt/v1/dinosaurs/${instanceId}`
-  );
+  const { data } = await apiRequest.get(`/api/rhacs/v1/centrals/${instanceId}`);
   return data;
 };
 

--- a/src/hooks/apis/useInstances.js
+++ b/src/hooks/apis/useInstances.js
@@ -6,7 +6,7 @@ import { getQueryString } from '../../utils/queryString';
 const getInstances = async ({ query }) => {
   const queryString = getQueryString(query);
   const { data } = await apiRequest.get(
-    `/api/dinosaurs_mgmt/v1/dinosaurs?${queryString}`
+    `/api/rhacs/v1/centrals?${queryString}`
   );
   return data;
 };


### PR DESCRIPTION
The backend APIs have changed since we first made the mock APIs. This PR will rename it to what was decided upon by the backend team

Backend API Spec: https://github.com/stackrox/acs-fleet-manager/blob/main/openapi/fleet-manager.yaml