### PR TITLE
fix: adding proper states for central instances and fixing the delete API

### DIFF
--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -1,31 +1,55 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { CheckCircleIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  PendingIcon,
+} from '@patternfly/react-icons';
 import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 
+const statusMessages = {
+  accepted: {
+    message: 'Request accepted',
+    component: <PendingIcon />,
+  },
+  preparing: {
+    message: 'Preparing instance',
+    component: <PendingIcon />,
+  },
+  provisioning: {
+    message: 'Creation in progress',
+    component: <Spinner isSVG size="md" />,
+  },
+  ready: {
+    message: 'Ready',
+    component: <CheckCircleIcon className="pf-u-success-color-100" />,
+  },
+  failed: {
+    message: 'Request failed',
+    component: <ExclamationCircleIcon className="pf-u-danger-color-100" />,
+  },
+  deprovision: {
+    message: 'Deprovisioning instance',
+    component: <Spinner isSVG size="md" />,
+  },
+  deleting: {
+    message: 'Deleting instance',
+    component: <Spinner isSVG size="md" />,
+  },
+};
+
 function Status({ status }) {
-  switch (status) {
-    case 'provisioning':
-      return (
-        <Flex>
-          <FlexItem>
-            <Spinner isSVG size="md" />
-          </FlexItem>
-          <FlexItem>Creation in progress</FlexItem>
-        </Flex>
-      );
-    case 'ready':
-      return (
-        <Flex>
-          <FlexItem>
-            <CheckCircleIcon className="pf-u-success-color-100" />
-          </FlexItem>
-          <FlexItem>Ready</FlexItem>
-        </Flex>
-      );
-    default:
-      return 'N/A';
-  }
+  const { message, component } = statusMessages[status] || {
+    message: 'N/A',
+    component: null,
+  };
+
+  return (
+    <Flex>
+      <FlexItem>{component}</FlexItem>
+      <FlexItem>{message}</FlexItem>
+    </Flex>
+  );
 }
 
 export default Status;

--- a/src/hooks/apis/useDeleteInstance.js
+++ b/src/hooks/apis/useDeleteInstance.js
@@ -4,7 +4,7 @@ import apiRequest from '../../services/apiRequest';
 
 const deleteInstance = async (instanceID) => {
   const { data } = await apiRequest.delete(
-    `/api/rhacs/v1/centrals/${instanceID}`
+    `/api/rhacs/v1/centrals/${instanceID}?async=true`
   );
   return data;
 };


### PR DESCRIPTION
Updates:

* Adding proper states for central instances requests: `accepted`, `preparing`, `provisioning`, `ready`, `failed`, `deprovision`, `deleting`
* Fixing the API for deleting an instance as backend suggested