### PR TITLE
fix: better error messages

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -23,7 +23,7 @@ const defaultFormValues = {
 };
 
 function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
-  const [error, setError] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
   const [formValues, setFormValues] = useState(defaultFormValues);
   const [isRequestingCreate, setIsRequestingCreate] = useState(false);
 
@@ -54,7 +54,8 @@ function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
     const result = await onRequestCreate(formValues);
     setIsRequestingCreate(false);
     if (result instanceof Error) {
-      setError(result);
+      const errorMessage = result.response.data.reason;
+      setErrorMessage(errorMessage);
     } else {
       setFormValues(defaultFormValues);
       onClose();
@@ -87,9 +88,9 @@ function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
         </Button>,
       ]}
     >
-      {error && (
+      {errorMessage && (
         <div className="pf-u-mb-md">
-          <Alert variant="danger" title={error.message} />
+          <Alert variant="danger" title={errorMessage} />
         </div>
       )}
       <Form>


### PR DESCRIPTION
A super simple change for better error messages when trying to create a central request

<img width="1440" alt="Screen Shot 2022-07-28 at 12 34 03 PM" src="https://user-images.githubusercontent.com/4805485/181622853-a154af69-528e-4689-b977-cc2b6223ed3a.png">
