### PR TITLE
feat: adding table sorting

### DIFF
--- a/src/hooks/useTableSort.js
+++ b/src/hooks/useTableSort.js
@@ -3,8 +3,6 @@ import { useEffect, useState } from 'react';
 function useTableSort({ sortFields, defaultSortOption }) {
   const [sortOption, setSortOption] = useState();
 
-  // get the sort option values from the URL, if available
-  // otherwise, use the default sort option values
   const activeSortField = sortOption?.field || defaultSortOption.field;
   const activeSortDirection =
     sortOption?.direction || defaultSortOption.direction;

--- a/src/hooks/useTableSort.js
+++ b/src/hooks/useTableSort.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+function useTableSort({ sortFields, defaultSortOption }) {
+  const [sortOption, setSortOption] = useState();
+
+  // get the sort option values from the URL, if available
+  // otherwise, use the default sort option values
+  const activeSortField = sortOption?.field || defaultSortOption.field;
+  const activeSortDirection =
+    sortOption?.direction || defaultSortOption.direction;
+
+  // we'll use this to map the sort fields to an id PatternFly can use internally
+  const [fieldToIdMap, setFieldToIdMap] = useState({});
+
+  // we'll construct a map of sort fields to ids that will make it easier to work with
+  // PatternFly
+  useEffect(() => {
+    const newFieldToIdMap = sortFields.reduce((acc, curr, index) => {
+      acc[curr] = index;
+      return acc;
+    }, {});
+    setFieldToIdMap(newFieldToIdMap);
+  }, [sortFields]);
+
+  function getSortParams(field) {
+    const fieldId = fieldToIdMap[field];
+    const activeSortId = activeSortField
+      ? fieldToIdMap[activeSortField]
+      : undefined;
+
+    return {
+      sortBy: {
+        index: activeSortId,
+        direction: activeSortDirection,
+        defaultDirection: 'desc',
+      },
+      onSort: (_event, _index, direction) => {
+        // modify the URL based on the new sort
+        const newSortOption = {
+          field,
+          direction,
+        };
+        setSortOption(newSortOption);
+      },
+      columnIndex: fieldId,
+    };
+  }
+
+  return {
+    sortOption: {
+      field: activeSortField,
+      direction: activeSortDirection,
+    },
+    getSortParams,
+  };
+}
+
+export default useTableSort;

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -42,6 +42,20 @@ import InstanceDetailsDrawer from './InstanceDetailsDrawer';
 import { getDateTime } from '../../utils/date';
 import Status from '../../components/Status';
 import InstancesToolbarSearchFilter from './InstancesToolbarSearchFilter';
+import useTableSort from '../../hooks/useTableSort';
+
+const sortFields = [
+  'name',
+  'cloud_provider',
+  'region',
+  'owner',
+  'status',
+  'created_at',
+];
+const defaultSortOption = {
+  field: 'name',
+  direction: 'asc',
+};
 
 /**
  * A smart component that handles all the api calls and data needed by the dumb components.
@@ -52,9 +66,21 @@ import InstancesToolbarSearchFilter from './InstancesToolbarSearchFilter';
  */
 function InstancesPage() {
   const history = useHistory();
+
   const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
+  const { sortOption, getSortParams } = useTableSort({
+    sortFields,
+    defaultSortOption,
+  });
   const [filters, setFilters] = useState({});
-  const { data, isFetching } = useInstances({ query: { page, size: perPage } });
+
+  const { data, isFetching } = useInstances({
+    query: {
+      page,
+      size: perPage,
+      orderBy: `${sortOption.field} ${sortOption.direction}`,
+    },
+  });
   const createInstance = useCreateInstance();
   const deleteInstance = useDeleteInstance();
   const [creatingInstance, setCreatingInstance] = useState(null);
@@ -172,12 +198,14 @@ function InstancesPage() {
               <TableComposable aria-label="ACS instances table">
                 <Thead>
                   <Tr>
-                    <Th>Name</Th>
-                    <Th>Cloud Provider</Th>
-                    <Th>Region</Th>
-                    <Th>Owner</Th>
-                    <Th>Status</Th>
-                    <Th>Time Created</Th>
+                    <Th sort={getSortParams('name')}>Name</Th>
+                    <Th sort={getSortParams('cloud_provider')}>
+                      Cloud Provider
+                    </Th>
+                    <Th sort={getSortParams('region')}>Region</Th>
+                    <Th sort={getSortParams('owner')}>Owner</Th>
+                    <Th sort={getSortParams('status')}>Status</Th>
+                    <Th sort={getSortParams('created_at')}>Time Created</Th>
                     <Th />
                   </Tr>
                 </Thead>


### PR DESCRIPTION
This change adds the ability to sort the table by column values. I am using the same `useTableSort` hook we employ in the `stackrox` project, but with a slight variation in the hook's output. Instead of using `reversed=true|false` we will be using `direction=asc|desc`

Note: I will try to add Typescript soon 😬 

<img width="1440" alt="Screen Shot 2022-07-28 at 1 04 29 PM" src="https://user-images.githubusercontent.com/4805485/181627321-b5fb34ec-abdb-428f-a728-d055b75a23ac.png">
