### PR TITLE
fix: change proxy from /api->fleet manager endpoint to /api/rhacs->fleet manager endpoint

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -12,7 +12,7 @@ function getEnv() {
 
 let customProxy = [
   {
-    context: ['/api'],
+    context: ['/api/rhacs'],
     target:
       process.env.FLEET_MANAGER_API_ENDPOINT ||
       'https://xtr6hh3mg6zc80v.api.stage.openshift.com',


### PR DESCRIPTION
This PR changes the proxy context from `/api` to `/api/rhacs` as a way to be safer about routing requests