### PR TITLE
fix: remove proxy and use api.stage.openshift.com instead

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,16 +10,6 @@ function getEnv() {
   }
 }
 
-let customProxy = [
-  {
-    context: ['/api/rhacs'],
-    target:
-      process.env.FLEET_MANAGER_API_ENDPOINT ||
-      'https://xtr6hh3mg6zc80v.api.stage.openshift.com',
-    changeOrigin: true,
-  },
-];
-
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
@@ -29,7 +19,6 @@ const { config: webpackConfig, plugins } = config({
     ? '/beta/application-services/acs'
     : '/application-services/acs',
   env: getEnv(),
-  customProxy,
 });
 plugins.push(...commonPlugins);
 

--- a/src/services/apiRequest.js
+++ b/src/services/apiRequest.js
@@ -4,6 +4,7 @@ export const authInterceptor = (client) => {
   client.interceptors.request.use(async (cfg) => {
     await insights.chrome.auth.getUser();
     const token = await insights.chrome.auth.getToken();
+    // @TODO: Allow flexibility of using staging environment vs. prod environment
     const BASE_URL = cfg.baseURL || 'https://api.stage.openshift.com';
     const updatedCfg = { ...cfg, url: `${BASE_URL}${cfg.url}` };
     if (token) {

--- a/src/services/apiRequest.js
+++ b/src/services/apiRequest.js
@@ -4,7 +4,7 @@ export const authInterceptor = (client) => {
   client.interceptors.request.use(async (cfg) => {
     await insights.chrome.auth.getUser();
     const token = await insights.chrome.auth.getToken();
-    const BASE_URL = cfg.baseURL || '';
+    const BASE_URL = cfg.baseURL || 'https://api.stage.openshift.com';
     const updatedCfg = { ...cfg, url: `${BASE_URL}${cfg.url}` };
     if (token) {
       updatedCfg.headers = {


### PR DESCRIPTION
This change removes the proxy to the Staging Fleet Manager API. Due to issues with sending a request directly to the endpoint, the backend had to make a change on the [app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/44681). The fleet manager API is now available under [api.stage.openshift.com](http://api.stage.openshift.com/) so we can send a request to there instead

<img width="1552" alt="Screen Shot 2022-08-05 at 11 12 41 AM" src="https://user-images.githubusercontent.com/4805485/183136690-b854ad9b-9b44-47a4-9b25-2aa121193098.png">
