### PR TITLE
fix: better format for date, cloud provider, and region

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -13,6 +13,8 @@ import {
   ToggleGroupItem,
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
+
+import { regionOptions } from '../../utils/region';
 import SelectSingle from '../../components/SelectSingle';
 
 const defaultFormValues = {
@@ -121,8 +123,13 @@ function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
             value={formValues.region}
             handleSelect={onCloudRegionSelect}
           >
-            <SelectOption value="us-east-1">US-East, N. Virginia</SelectOption>
-            <SelectOption value="eu-west-1">EU-Ireland</SelectOption>
+            {regionOptions.map((region) => {
+              return (
+                <SelectOption key={region.value} value={region.value}>
+                  {region.label}
+                </SelectOption>
+              );
+            })}
           </SelectSingle>
         </FormGroup>
         <FormGroup

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -43,6 +43,8 @@ import { getDateTime } from '../../utils/date';
 import Status from '../../components/Status';
 import InstancesToolbarSearchFilter from './InstancesToolbarSearchFilter';
 import useTableSort from '../../hooks/useTableSort';
+import { regionValueToLabel } from '../../utils/region';
+import { cloudProviderValueToLabel } from '../../utils/cloudProvider';
 
 const sortFields = [
   'name',
@@ -210,56 +212,57 @@ function InstancesPage() {
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {instances.map((instance) => (
-                    <Tr
-                      key={instance.name}
-                      onRowClick={(event) => {
-                        if (event.target.getAttribute('type') !== 'button') {
-                          setViewingInstance(instance);
-                        }
-                      }}
-                      isRowSelected={viewingInstance?.name === instance?.name}
-                    >
-                      <Td dataLabel="Name">
-                        <Link to={`/instances/instance/${instance.id}`}>
-                          {instance.name}
-                        </Link>
-                      </Td>
-                      <Td dataLabel="Cloud Provider">
-                        {instance.cloud_provider}
-                      </Td>
-                      <Td dataLabel="Region">{instance.region}</Td>
-                      <Td dataLabel="Owner">{instance.owner}</Td>
-                      <Td dataLabel="Status">
-                        <Status status={instance.status} />
-                      </Td>
-                      <Td dataLabel="Time Created<">
-                        {getDateTime(instance.created_at)}
-                      </Td>
-                      <Td isActionCell>
-                        <ActionsColumn
-                          items={[
-                            {
-                              title: 'Details',
-                              onClick: (event) => {
-                                event.preventDefault();
-                                history.push(
-                                  `/instances/instance/${instance.id}`
-                                );
+                  {instances.map((instance) => {
+                    const instanceDetailsURL = `/instances/instance/${instance.id}`;
+                    return (
+                      <Tr
+                        key={instance.name}
+                        onRowClick={(event) => {
+                          if (event.target.getAttribute('type') !== 'button') {
+                            setViewingInstance(instance);
+                          }
+                        }}
+                        isRowSelected={viewingInstance?.name === instance?.name}
+                      >
+                        <Td dataLabel="Name">
+                          <Link to={instanceDetailsURL}>{instance.name}</Link>
+                        </Td>
+                        <Td dataLabel="Cloud Provider">
+                          {cloudProviderValueToLabel(instance.cloud_provider)}
+                        </Td>
+                        <Td dataLabel="Region">
+                          {regionValueToLabel(instance.region)}
+                        </Td>
+                        <Td dataLabel="Owner">{instance.owner}</Td>
+                        <Td dataLabel="Status">
+                          <Status status={instance.status} />
+                        </Td>
+                        <Td dataLabel="Time Created<">
+                          {getDateTime(instance.created_at)}
+                        </Td>
+                        <Td isActionCell>
+                          <ActionsColumn
+                            items={[
+                              {
+                                title: 'Details',
+                                onClick: (event) => {
+                                  event.preventDefault();
+                                  history.push(instanceDetailsURL);
+                                },
                               },
-                            },
-                            {
-                              title: 'Delete',
-                              onClick: (event) => {
-                                event.preventDefault();
-                                setDeletingInstance(instance);
+                              {
+                                title: 'Delete',
+                                onClick: (event) => {
+                                  event.preventDefault();
+                                  setDeletingInstance(instance);
+                                },
                               },
-                            },
-                          ]}
-                        />
-                      </Td>
-                    </Tr>
-                  ))}
+                            ]}
+                          />
+                        </Td>
+                      </Tr>
+                    );
+                  })}
                 </Tbody>
               </TableComposable>
               <Toolbar>

--- a/src/utils/cloudProvider.js
+++ b/src/utils/cloudProvider.js
@@ -1,0 +1,16 @@
+const cloudProviders = {
+  aws: 'Amazon Web Services',
+};
+
+export const cloudProviderOptions = Object.keys(cloudProviders).map(
+  (cloudProviderValue) => {
+    return {
+      value: cloudProviderValue,
+      label: cloudProviders[cloudProviderValue],
+    };
+  }
+);
+
+export function cloudProviderValueToLabel(cloudProviderValue) {
+  return cloudProviders[cloudProviderValue];
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,7 +1,7 @@
-import { format, parseISO } from 'date-fns';
-
-const dateTimeFormat = 'MM/dd/yyyy | h:mm:ss a';
+import { parseISO, formatDistance } from 'date-fns';
 
 export function getDateTime(timestamp) {
-  return format(parseISO(timestamp), dateTimeFormat);
+  return formatDistance(parseISO(timestamp), new Date(), {
+    addSuffix: true,
+  });
 }

--- a/src/utils/region.js
+++ b/src/utils/region.js
@@ -1,0 +1,12 @@
+const regions = {
+  'us-east-1': 'US-East, N. Virginia',
+  'eu-west-1': 'EU-Ireland',
+};
+
+export const regionOptions = Object.keys(regions).map((regionValue) => {
+  return { value: regionValue, label: regions[regionValue] };
+});
+
+export function regionValueToLabel(regionValue) {
+  return regions[regionValue];
+}


### PR DESCRIPTION
### Description 

Modifying the values in the table to look a little nicer and more human readable

### Before
<img width="1552" alt="Screen Shot 2022-08-15 at 1 50 24 PM" src="https://user-images.githubusercontent.com/4805485/184716210-7dcf78c0-f607-4337-a23f-0444b8c99b4f.png">

### After
<img width="1552" alt="Screen Shot 2022-08-15 at 1 49 15 PM" src="https://user-images.githubusercontent.com/4805485/184716200-855f2b24-3563-4ae4-9ec2-7e62505103c0.png">
