### PR TITLE
fix: use correct url for 'Sign in to ACS Instance' button

### DIFF
--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -77,7 +77,7 @@ function InstanceDetailsPage() {
               <Button
                 variant={ButtonVariant.primary}
                 component="a"
-                href="https://k8s.demo.stackrox.com/login"
+                href={`https://${instance.host}`}
                 target="_blank"
               >
                 Sign in to ACS Instance


### PR DESCRIPTION
### Description

We want to use the Instance's `host` value for the `Sign in to ACS Instance` button so the user can access the UI endpoint. This replaces the placeholder we had before