### PR TITLE
feat: integrate table filters with api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9439,7 +9439,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-id": {
       "version": "0.14.1",
@@ -20838,7 +20839,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-id": {
       "version": "0.14.1",

--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -7,33 +7,35 @@ import {
 } from '@patternfly/react-icons';
 import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 
+import { statuses } from '../utils/status';
+
 const statusMessages = {
   accepted: {
-    message: 'Request accepted',
+    message: statuses.accepted,
     component: <PendingIcon />,
   },
   preparing: {
-    message: 'Preparing instance',
+    message: statuses.preparing,
     component: <PendingIcon />,
   },
   provisioning: {
-    message: 'Creation in progress',
+    message: statuses.provisioning,
     component: <Spinner isSVG size="md" />,
   },
   ready: {
-    message: 'Ready',
+    message: statuses.ready,
     component: <CheckCircleIcon className="pf-u-success-color-100" />,
   },
   failed: {
-    message: 'Request failed',
+    message: statuses.failed,
     component: <ExclamationCircleIcon className="pf-u-danger-color-100" />,
   },
   deprovision: {
-    message: 'Deprovisioning instance',
+    message: statuses.deprovision,
     component: <Spinner isSVG size="md" />,
   },
   deleting: {
-    message: 'Deleting instance',
+    message: statuses.deleting,
     component: <Spinner isSVG size="md" />,
   },
 };

--- a/src/routes/InstancesPage/InstanceDetailsDrawer.js
+++ b/src/routes/InstancesPage/InstanceDetailsDrawer.js
@@ -19,6 +19,8 @@ import {
 import React from 'react';
 
 import { getDateTime } from '../../utils/date';
+import { cloudProviderValueToLabel } from '../../utils/cloudProvider';
+import { regionValueToLabel } from '../../utils/region';
 
 function InstanceDetailsDrawer({ isExpanded, onClose, instance, children }) {
   return (
@@ -32,7 +34,7 @@ function InstanceDetailsDrawer({ isExpanded, onClose, instance, children }) {
                   <Text component={TextVariants.small}>Name</Text>
                 </TextContent>
                 <TextContent>
-                  <Text component={TextVariants.h1}>{instance?.name}</Text>
+                  <Text component={TextVariants.h2}>{instance?.name}</Text>
                 </TextContent>
               </div>
               <DrawerActions>
@@ -43,18 +45,6 @@ function InstanceDetailsDrawer({ isExpanded, onClose, instance, children }) {
             <DrawerContentBody>
               {instance && (
                 <DescriptionList isHorizontal>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Cloud provider</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {instance.cloud_provider}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Region</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {instance.region}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
                   <DescriptionListGroup>
                     <DescriptionListTerm>ID</DescriptionListTerm>
                     <DescriptionListDescription>
@@ -68,15 +58,27 @@ function InstanceDetailsDrawer({ isExpanded, onClose, instance, children }) {
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                   <DescriptionListGroup>
-                    <DescriptionListTerm>Created</DescriptionListTerm>
+                    <DescriptionListTerm>Time created</DescriptionListTerm>
                     <DescriptionListDescription>
                       {getDateTime(instance.created_at)}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                   <DescriptionListGroup>
-                    <DescriptionListTerm>Updated</DescriptionListTerm>
+                    <DescriptionListTerm>Time updated</DescriptionListTerm>
                     <DescriptionListDescription>
                       {getDateTime(instance.updated_at)}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Cloud provider</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {cloudProviderValueToLabel(instance.cloud_provider)}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Region</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {regionValueToLabel(instance.region)}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 </DescriptionList>

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -18,7 +18,7 @@ import {
   ToolbarItem,
   Pagination,
   Bullseye,
-  Spinner,
+  EmptyStateVariant,
 } from '@patternfly/react-core';
 import {
   ActionsColumn,
@@ -29,7 +29,7 @@ import {
   Thead,
   Tr,
 } from '@patternfly/react-table';
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, SearchIcon } from '@patternfly/react-icons';
 
 import usePagination from '../../hooks/usePagination';
 import useInstances from '../../hooks/apis/useInstances';
@@ -45,6 +45,7 @@ import InstancesToolbarSearchFilter from './InstancesToolbarSearchFilter';
 import useTableSort from '../../hooks/useTableSort';
 import { regionValueToLabel } from '../../utils/region';
 import { cloudProviderValueToLabel } from '../../utils/cloudProvider';
+import { filtersToSearchQuery } from '../../utils/searchQuery';
 
 const sortFields = [
   'name',
@@ -81,6 +82,7 @@ function InstancesPage() {
       page,
       size: perPage,
       orderBy: `${sortOption.field} ${sortOption.direction}`,
+      search: filtersToSearchQuery(filters),
     },
   });
   const createInstance = useCreateInstance();
@@ -92,7 +94,7 @@ function InstancesPage() {
   const instances = data?.items || [];
 
   useEffect(() => {
-    insights?.chrome?.appAction?.('sample-page');
+    insights?.chrome?.appAction?.('instances-page');
   }, []);
 
   function onRequestCreate(values) {
@@ -130,11 +132,166 @@ function InstancesPage() {
     setFilters({});
   }
 
-  if (isFetching) {
-    return (
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
+  let content = null;
+
+  if (
+    !isFetching &&
+    instances.length === 0 &&
+    Object.keys(filters).length === 0
+  ) {
+    content = (
+      <EmptyState>
+        <EmptyStateIcon icon={CubesIcon} />
+        <Title size="lg" headingLevel="h4">
+          No ACS instances.
+        </Title>
+        <EmptyStateBody>Create one to get started.</EmptyStateBody>
+        <EmptyStatePrimary>
+          <Button variant="primary" onClick={() => setCreatingInstance({})}>
+            Create ACS instance
+          </Button>
+        </EmptyStatePrimary>
+      </EmptyState>
+    );
+  } else {
+    content = (
+      <>
+        <Toolbar clearAllFilters={onClearFilters}>
+          <ToolbarContent>
+            <InstancesToolbarSearchFilter
+              filters={filters}
+              setFilters={setFilters}
+            />
+            <ToolbarItem>
+              <Button variant="primary" onClick={() => setCreatingInstance({})}>
+                Create ACS instance
+              </Button>
+            </ToolbarItem>
+            {instances.length !== 0 && (
+              <ToolbarItem
+                variant="pagination"
+                align={{ default: 'alignRight' }}
+              >
+                <Pagination
+                  itemCount={instances.length}
+                  perPage={perPage}
+                  page={page}
+                  onSetPage={onSetPage}
+                  widgetId="acs-instances-top-pagination"
+                  onPerPageSelect={onPerPageSelect}
+                  isCompact
+                />
+              </ToolbarItem>
+            )}
+          </ToolbarContent>
+        </Toolbar>
+        <TableComposable aria-label="ACS instances table">
+          <Thead>
+            <Tr>
+              <Th sort={getSortParams('name')}>Name</Th>
+              <Th sort={getSortParams('cloud_provider')}>Cloud Provider</Th>
+              <Th sort={getSortParams('region')}>Region</Th>
+              <Th sort={getSortParams('owner')}>Owner</Th>
+              <Th sort={getSortParams('status')}>Status</Th>
+              <Th sort={getSortParams('created_at')}>Time Created</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {!isFetching && instances.length === 0 ? (
+              <Tr>
+                <Td colSpan={8}>
+                  <Bullseye>
+                    <EmptyState variant={EmptyStateVariant.small}>
+                      <EmptyStateIcon icon={SearchIcon} />
+                      <Title headingLevel="h2" size="lg">
+                        No results found
+                      </Title>
+                      <EmptyStateBody>
+                        Clear all filters and try again.
+                      </EmptyStateBody>
+                      <Button variant="link" onClick={onClearFilters}>
+                        Clear all filters
+                      </Button>
+                    </EmptyState>
+                  </Bullseye>
+                </Td>
+              </Tr>
+            ) : (
+              instances.map((instance) => {
+                const instanceDetailsURL = `/instances/instance/${instance.id}`;
+                return (
+                  <Tr
+                    key={instance.name}
+                    onRowClick={(event) => {
+                      if (event.target.getAttribute('type') !== 'button') {
+                        setViewingInstance(instance);
+                      }
+                    }}
+                    isRowSelected={viewingInstance?.name === instance?.name}
+                  >
+                    <Td dataLabel="Name">
+                      <Link to={instanceDetailsURL}>{instance.name}</Link>
+                    </Td>
+                    <Td dataLabel="Cloud Provider">
+                      {cloudProviderValueToLabel(instance.cloud_provider)}
+                    </Td>
+                    <Td dataLabel="Region">
+                      {regionValueToLabel(instance.region)}
+                    </Td>
+                    <Td dataLabel="Owner">{instance.owner}</Td>
+                    <Td dataLabel="Status">
+                      <Status status={instance.status} />
+                    </Td>
+                    <Td dataLabel="Time Created<">
+                      {getDateTime(instance.created_at)}
+                    </Td>
+                    <Td isActionCell>
+                      <ActionsColumn
+                        items={[
+                          {
+                            title: 'Details',
+                            onClick: (event) => {
+                              event.preventDefault();
+                              history.push(instanceDetailsURL);
+                            },
+                          },
+                          {
+                            title: 'Delete',
+                            onClick: (event) => {
+                              event.preventDefault();
+                              setDeletingInstance(instance);
+                            },
+                          },
+                        ]}
+                      />
+                    </Td>
+                  </Tr>
+                );
+              })
+            )}
+          </Tbody>
+        </TableComposable>
+        {instances.length !== 0 && (
+          <Toolbar>
+            <ToolbarContent>
+              <ToolbarItem
+                variant="pagination"
+                align={{ default: 'alignRight' }}
+              >
+                <Pagination
+                  itemCount={instances.length}
+                  perPage={perPage}
+                  page={page}
+                  onSetPage={onSetPage}
+                  widgetId="acs-instances-top-pagination"
+                  onPerPageSelect={onPerPageSelect}
+                />
+              </ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
+        )}
+      </>
     );
   }
 
@@ -148,143 +305,7 @@ function InstancesPage() {
         <PageHeaderTitle title="ACS Instances" />
       </PageHeader>
       <Main>
-        <Card>
-          {instances?.length === 0 ? (
-            <EmptyState>
-              <EmptyStateIcon icon={CubesIcon} />
-              <Title size="lg" headingLevel="h4">
-                No ACS instances.
-              </Title>
-              <EmptyStateBody>Create one to get started.</EmptyStateBody>
-              <EmptyStatePrimary>
-                <Button
-                  variant="primary"
-                  onClick={() => setCreatingInstance({})}
-                >
-                  Create ACS instance
-                </Button>
-              </EmptyStatePrimary>
-            </EmptyState>
-          ) : (
-            <>
-              <Toolbar clearAllFilters={onClearFilters}>
-                <ToolbarContent>
-                  <InstancesToolbarSearchFilter
-                    filters={filters}
-                    setFilters={setFilters}
-                  />
-                  <ToolbarItem>
-                    <Button
-                      variant="primary"
-                      onClick={() => setCreatingInstance({})}
-                    >
-                      Create ACS instance
-                    </Button>
-                  </ToolbarItem>
-                  <ToolbarItem
-                    variant="pagination"
-                    align={{ default: 'alignRight' }}
-                  >
-                    <Pagination
-                      itemCount={instances.length}
-                      perPage={perPage}
-                      page={page}
-                      onSetPage={onSetPage}
-                      widgetId="acs-instances-top-pagination"
-                      onPerPageSelect={onPerPageSelect}
-                      isCompact
-                    />
-                  </ToolbarItem>
-                </ToolbarContent>
-              </Toolbar>
-              <TableComposable aria-label="ACS instances table">
-                <Thead>
-                  <Tr>
-                    <Th sort={getSortParams('name')}>Name</Th>
-                    <Th sort={getSortParams('cloud_provider')}>
-                      Cloud Provider
-                    </Th>
-                    <Th sort={getSortParams('region')}>Region</Th>
-                    <Th sort={getSortParams('owner')}>Owner</Th>
-                    <Th sort={getSortParams('status')}>Status</Th>
-                    <Th sort={getSortParams('created_at')}>Time Created</Th>
-                    <Th />
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {instances.map((instance) => {
-                    const instanceDetailsURL = `/instances/instance/${instance.id}`;
-                    return (
-                      <Tr
-                        key={instance.name}
-                        onRowClick={(event) => {
-                          if (event.target.getAttribute('type') !== 'button') {
-                            setViewingInstance(instance);
-                          }
-                        }}
-                        isRowSelected={viewingInstance?.name === instance?.name}
-                      >
-                        <Td dataLabel="Name">
-                          <Link to={instanceDetailsURL}>{instance.name}</Link>
-                        </Td>
-                        <Td dataLabel="Cloud Provider">
-                          {cloudProviderValueToLabel(instance.cloud_provider)}
-                        </Td>
-                        <Td dataLabel="Region">
-                          {regionValueToLabel(instance.region)}
-                        </Td>
-                        <Td dataLabel="Owner">{instance.owner}</Td>
-                        <Td dataLabel="Status">
-                          <Status status={instance.status} />
-                        </Td>
-                        <Td dataLabel="Time Created<">
-                          {getDateTime(instance.created_at)}
-                        </Td>
-                        <Td isActionCell>
-                          <ActionsColumn
-                            items={[
-                              {
-                                title: 'Details',
-                                onClick: (event) => {
-                                  event.preventDefault();
-                                  history.push(instanceDetailsURL);
-                                },
-                              },
-                              {
-                                title: 'Delete',
-                                onClick: (event) => {
-                                  event.preventDefault();
-                                  setDeletingInstance(instance);
-                                },
-                              },
-                            ]}
-                          />
-                        </Td>
-                      </Tr>
-                    );
-                  })}
-                </Tbody>
-              </TableComposable>
-              <Toolbar>
-                <ToolbarContent>
-                  <ToolbarItem
-                    variant="pagination"
-                    align={{ default: 'alignRight' }}
-                  >
-                    <Pagination
-                      itemCount={instances.length}
-                      perPage={perPage}
-                      page={page}
-                      onSetPage={onSetPage}
-                      widgetId="acs-instances-top-pagination"
-                      onPerPageSelect={onPerPageSelect}
-                    />
-                  </ToolbarItem>
-                </ToolbarContent>
-              </Toolbar>
-            </>
-          )}
-        </Card>
+        <Card>{content}</Card>
         <CreateInstanceModal
           isOpen={!!creatingInstance}
           onClose={closeCreateInstanceModal}

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -39,7 +39,7 @@ import useDeleteInstance from '../../hooks/apis/useDeleteInstance';
 import CreateInstanceModal from './CreateInstanceModal';
 import DeleteInstanceModal from './DeleteInstanceModal';
 import InstanceDetailsDrawer from './InstanceDetailsDrawer';
-import { getDateTime } from '../../utils/date';
+import { getDateTimeDifference } from '../../utils/date';
 import Status from '../../components/Status';
 import InstancesToolbarSearchFilter from './InstancesToolbarSearchFilter';
 import useTableSort from '../../hooks/useTableSort';
@@ -189,11 +189,11 @@ function InstancesPage() {
           <Thead>
             <Tr>
               <Th sort={getSortParams('name')}>Name</Th>
-              <Th sort={getSortParams('cloud_provider')}>Cloud Provider</Th>
+              <Th sort={getSortParams('cloud_provider')}>Cloud provider</Th>
               <Th sort={getSortParams('region')}>Region</Th>
               <Th sort={getSortParams('owner')}>Owner</Th>
               <Th sort={getSortParams('status')}>Status</Th>
-              <Th sort={getSortParams('created_at')}>Time Created</Th>
+              <Th sort={getSortParams('created_at')}>Time created</Th>
               <Th />
             </Tr>
           </Thead>
@@ -233,7 +233,7 @@ function InstancesPage() {
                     <Td dataLabel="Name">
                       <Link to={instanceDetailsURL}>{instance.name}</Link>
                     </Td>
-                    <Td dataLabel="Cloud Provider">
+                    <Td dataLabel="Cloud provider">
                       {cloudProviderValueToLabel(instance.cloud_provider)}
                     </Td>
                     <Td dataLabel="Region">
@@ -243,8 +243,8 @@ function InstancesPage() {
                     <Td dataLabel="Status">
                       <Status status={instance.status} />
                     </Td>
-                    <Td dataLabel="Time Created<">
-                      {getDateTime(instance.created_at)}
+                    <Td dataLabel="Time created">
+                      {getDateTimeDifference(instance.created_at)}
                     </Td>
                     <Td isActionCell>
                       <ActionsColumn

--- a/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
+++ b/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
@@ -13,6 +13,9 @@ import {
   Button,
 } from '@patternfly/react-core';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+
+import { regionOptions } from '../../utils/region';
+import { statusOptions } from '../../utils/status';
 import SelectSingle from '../../components/SelectSingle';
 
 function InstancesToolbarSearchFilter({ filters, setFilters }) {
@@ -29,9 +32,12 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
   function onDeleteChip(type = '', id = '') {
     setFilters((prevFilters) => {
       const newFilters = { ...prevFilters };
-      newFilters[type.toLowerCase()] = newFilters[type.toLowerCase()].filter(
-        (s) => s !== id
-      );
+      const newValue = newFilters[type.toLowerCase()].filter((s) => s !== id);
+      if (newValue?.length === 0) {
+        delete newFilters[type.toLowerCase()];
+      } else {
+        newFilters[type.toLowerCase()] = newValue;
+      }
       return newFilters;
     });
   }
@@ -40,7 +46,7 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
   function onDeleteChipGroup(type) {
     setFilters((prevFilters) => {
       const newFilters = { ...prevFilters };
-      newFilters[type.toLowerCase()] = [];
+      delete newFilters[type.toLowerCase()];
       return newFilters;
     });
   }
@@ -49,13 +55,17 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
   function onSelect(type, event, selection) {
     const checked = event.target.checked;
     setFilters((prevFilters) => {
+      const newFilters = { ...prevFilters };
       const prevSelections = prevFilters[type] || [];
-      return {
-        ...prevFilters,
-        [type]: checked
-          ? [...prevSelections, selection]
-          : prevSelections.filter((value) => value !== selection),
-      };
+      const newValue = checked
+        ? [...prevSelections, selection]
+        : prevSelections.filter((value) => value !== selection);
+      if (newValue.length === 0) {
+        delete newFilters[type];
+      } else {
+        newFilters[type] = newValue;
+      }
+      return newFilters;
     });
   }
 
@@ -136,10 +146,16 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
               isOpen={isRegionExpanded}
               placeholderText="Filter by region"
             >
-              <SelectOption value="US-East, N. Virginia">
-                US-East, N. Virginia
-              </SelectOption>
-              <SelectOption value="EU-Ireland">EU-Ireland</SelectOption>
+              {regionOptions.map((regionOption) => {
+                return (
+                  <SelectOption
+                    key={regionOption.label}
+                    value={regionOption.label}
+                  >
+                    {regionOption.label}
+                  </SelectOption>
+                );
+              })}
             </Select>
           </ToolbarItem>
         </ToolbarFilter>
@@ -194,15 +210,16 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
               isOpen={isStatusExpanded}
               placeholderText="Filter by status"
             >
-              <SelectOption value="Ready">Ready</SelectOption>
-              <SelectOption value="Failed">Failed</SelectOption>
-              <SelectOption value="Creation pending">
-                Creation pending
-              </SelectOption>
-              <SelectOption value="Creation in progress">
-                Creation in progress
-              </SelectOption>
-              <SelectOption value="Deleting">Deleting</SelectOption>
+              {statusOptions.map((statusOption) => {
+                return (
+                  <SelectOption
+                    key={statusOption.label}
+                    value={statusOption.label}
+                  >
+                    {statusOption.label}
+                  </SelectOption>
+                );
+              })}
             </Select>
           </ToolbarItem>
         </ToolbarFilter>

--- a/src/utils/cloudProvider.js
+++ b/src/utils/cloudProvider.js
@@ -14,3 +14,10 @@ export const cloudProviderOptions = Object.keys(cloudProviders).map(
 export function cloudProviderValueToLabel(cloudProviderValue) {
   return cloudProviders[cloudProviderValue];
 }
+
+export function cloudProviderLabelToValue(cloudProviderLabel) {
+  const cloudProviderOption = cloudProviderOptions.find(
+    (cloudProviderOption) => cloudProviderOption.label === cloudProviderLabel
+  );
+  return cloudProviderOption?.value;
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,7 +1,13 @@
-import { parseISO, formatDistance } from 'date-fns';
+import { parseISO, format, formatDistance } from 'date-fns';
 
-export function getDateTime(timestamp) {
+const dateTimeFormat = 'MM/dd/yyyy | h:mm:ss a';
+
+export function getDateTimeDifference(timestamp) {
   return formatDistance(parseISO(timestamp), new Date(), {
     addSuffix: true,
   });
+}
+
+export function getDateTime(timestamp) {
+  return format(parseISO(timestamp), dateTimeFormat);
 }

--- a/src/utils/region.js
+++ b/src/utils/region.js
@@ -10,3 +10,10 @@ export const regionOptions = Object.keys(regions).map((regionValue) => {
 export function regionValueToLabel(regionValue) {
   return regions[regionValue];
 }
+
+export function regionLabelToValue(regionLabel) {
+  const regionOption = regionOptions.find(
+    (regionOption) => regionOption.label === regionLabel
+  );
+  return regionOption?.value;
+}

--- a/src/utils/searchQuery.js
+++ b/src/utils/searchQuery.js
@@ -1,0 +1,33 @@
+import { regionLabelToValue } from './region';
+import { cloudProviderLabelToValue } from './cloudProvider';
+import { statusLabelToValue } from './status';
+
+export function filtersToSearchQuery(filters) {
+  const searchCategories = Object.keys(filters);
+  const queries =
+    searchCategories
+      .filter((searchCategory) => {
+        const searchValues = filters[searchCategory];
+        return searchValues.length;
+      })
+      .map((searchCategory) => {
+        const searchValues = filters[searchCategory];
+        const searchCategoryResult = searchValues
+          .map((searchValue) => {
+            // Use the value the API needs rather than the human readable UI value
+            let modifiedSearchValue = searchValue;
+            if (searchCategory === 'cloud_provider') {
+              modifiedSearchValue = cloudProviderLabelToValue(searchValue);
+            } else if (searchCategory === 'region') {
+              modifiedSearchValue = regionLabelToValue(searchValue);
+            } else if (searchCategory === 'status') {
+              modifiedSearchValue = statusLabelToValue(searchValue);
+            }
+            return `${searchCategory} = ${modifiedSearchValue}`;
+          })
+          .join(' or ');
+        return `(${searchCategoryResult})`;
+      })
+      .join(' and ') || '';
+  return queries;
+}

--- a/src/utils/searchQuery.test.js
+++ b/src/utils/searchQuery.test.js
@@ -1,0 +1,74 @@
+import { filtersToSearchQuery } from './searchQuery';
+
+describe('searchQuery', () => {
+  describe('filtersToSearchQuery', () => {
+    it('should return an empty search query', () => {
+      const filters = {};
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe('');
+    });
+
+    it('should return the correct search query for the name category', () => {
+      const filters = {
+        name: ['sc-test-1'],
+      };
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe('(name = sc-test-1)');
+    });
+
+    it('should return the correct search query for the region category', () => {
+      const filters = {
+        region: ['US-East, N. Virginia', 'EU-Ireland'],
+      };
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe('(region = us-east-1 or region = eu-west-1)');
+    });
+
+    it('should return the correct search query for the owner category', () => {
+      const filters = {
+        owner: ['schaudhr'],
+      };
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe('(owner = schaudhr)');
+    });
+
+    it('should return the correct search query for the status category', () => {
+      const filters = {
+        status: [
+          'Request accepted',
+          'Creation pending',
+          'Creation in progress',
+          'Ready',
+          'Failed',
+          'Deprovisioning',
+          'Deleting',
+        ],
+      };
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe(
+        '(status = accepted or status = preparing or status = provisioning or status = ready or status = failed or status = deprovision or status = deleting)'
+      );
+    });
+
+    it('should return the correct search query for multiple categories', () => {
+      const filters = {
+        name: ['sc-test-1'],
+        region: ['US-East, N. Virginia', 'EU-Ireland'],
+        owner: ['schaudhr'],
+      };
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe(
+        '(name = sc-test-1) and (region = us-east-1 or region = eu-west-1) and (owner = schaudhr)'
+      );
+    });
+
+    it('should return the correct search query for multiple categories where one category has an empty array', () => {
+      const filters = {
+        name: ['sc-test-1'],
+        owner: [],
+      };
+      const searchQuery = filtersToSearchQuery(filters);
+      expect(searchQuery).toBe('(name = sc-test-1)');
+    });
+  });
+});

--- a/src/utils/status.js
+++ b/src/utils/status.js
@@ -1,0 +1,27 @@
+export const statuses = {
+  accepted: 'Request accepted',
+  preparing: 'Creation pending',
+  provisioning: 'Creation in progress',
+  ready: 'Ready',
+  failed: 'Failed',
+  deprovision: 'Deprovisioning',
+  deleting: 'Deleting',
+};
+
+export const statusOptions = Object.keys(statuses).map((statusValue) => {
+  return {
+    value: statusValue,
+    label: statuses[statusValue],
+  };
+});
+
+export function statusValueToLabel(statusValue) {
+  return statuses[statusValue];
+}
+
+export function statusLabelToValue(statusLabel) {
+  const statusOption = statusOptions.find(
+    (statusOption) => statusOption.label === statusLabel
+  );
+  return statusOption?.value;
+}


### PR DESCRIPTION
### Description

This PR makes a few tweaks to the table filters to be able to be used with the API to filter the data. Some changes made in this PR include the following:

1. Three util files were created `status`, `cloudProvider` and `region` in order to expose a few things:
    a. A `key-value` object where the `key` is the API-specific value and the `value` is the human-readable value (ie. `us-east-1` and `US-East, N. Virginia`)
    b. An array of objects with a `value` and `label` that we can use for some of our select components
    c. a `_ValueToLabel` and `_LabelToValue` function that lets us convert between something like `us-east-1` -> `US-East, N. Virginia` and `US-East, N. Virginia` -> `us-east-1`
2. A util file called `searchQuery` was added that exposes a function called `filtersToSearchQuery` that converts the filters object to a search query that we can supply to our API calls. The format of the returned string looks like this:

```
const filters = { name: ['sc-test-1'], region: ['US-East, N. Virginia', 'EU-Ireland'] };
filtersToSearchQuery(filters) => "(name = sc-test-1) and (region = us-east-1 or region = eu-west-1)"
```
The supplied search values will be transformed from the human-readable values to the values necessary for the API call

3. The `onDeleteChip` and `onDeleteChipGroup` functions were tweaked to fix a bug where we'd sometimes have a filter like this:

```
{ region: [] }
```

Now we'll remove fields where there are no values selected for that search category