### PR TITLE
feat: use the correct marketing video

### DIFF
--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -98,8 +98,8 @@ function InstanceDetailsPage() {
             <GridItem md={7}>
               <Card className="marketing-video">
                 <iframe
-                  src="https://www.youtube.com/embed/HhYYuGTa63E"
-                  title="YouTube video player"
+                  src="https://www.youtube.com/embed/wMJMFIeVsw8"
+                  title="Advanced Cluster Security in 2 Minutes"
                   frameBorder="0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                   allowFullScreen


### PR DESCRIPTION
### Description

This PR changes the video used in the instance details view to use the correct `Advanced Cluster Security in 2 minutes` youtube video

### Screenshot 

<img width="721" alt="Screen Shot 2022-08-17 at 1 13 49 PM" src="https://user-images.githubusercontent.com/4805485/185234962-51b44cb2-6a4d-4f53-9394-182fcd79ab7f.png">
