### PR TITLE
refactor: improving the details page

### DIFF
--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -15,6 +15,18 @@ function InstanceDetailsList({ instance }) {
   return (
     <DescriptionList isHorizontal>
       <DescriptionListGroup>
+        <DescriptionListTerm>Cloud provider</DescriptionListTerm>
+        <DescriptionListDescription>
+          {cloudProviderValueToLabel(instance.cloud_provider)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Region</DescriptionListTerm>
+        <DescriptionListDescription>
+          {regionValueToLabel(instance.region)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
         <DescriptionListTerm>ID</DescriptionListTerm>
         <DescriptionListDescription>{instance.id}</DescriptionListDescription>
       </DescriptionListGroup>
@@ -37,24 +49,16 @@ function InstanceDetailsList({ instance }) {
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
-        <DescriptionListTerm>Cloud provider</DescriptionListTerm>
-        <DescriptionListDescription>
-          {cloudProviderValueToLabel(instance.cloud_provider)}
-        </DescriptionListDescription>
-      </DescriptionListGroup>
-      <DescriptionListGroup>
-        <DescriptionListTerm>Region</DescriptionListTerm>
-        <DescriptionListDescription>
-          {regionValueToLabel(instance.region)}
-        </DescriptionListDescription>
-      </DescriptionListGroup>
-      <DescriptionListGroup>
         <DescriptionListTerm>Sensor Host URL</DescriptionListTerm>
-        <DescriptionListDescription>-</DescriptionListDescription>
+        <DescriptionListDescription>
+          {instance.centralDataURL}
+        </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Central UI</DescriptionListTerm>
-        <DescriptionListDescription>{instance.host}</DescriptionListDescription>
+        <DescriptionListDescription>
+          {instance.centralUIURL}
+        </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>
   );

--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -1,0 +1,63 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
+
+import { getDateTime } from '../utils/date';
+import { cloudProviderValueToLabel } from '../utils/cloudProvider';
+import { regionValueToLabel } from '../utils/region';
+
+function InstanceDetailsList({ instance }) {
+  return (
+    <DescriptionList isHorizontal>
+      <DescriptionListGroup>
+        <DescriptionListTerm>ID</DescriptionListTerm>
+        <DescriptionListDescription>{instance.id}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Owner</DescriptionListTerm>
+        <DescriptionListDescription>
+          {instance.owner}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Time created</DescriptionListTerm>
+        <DescriptionListDescription>
+          {getDateTime(instance.created_at)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Time updated</DescriptionListTerm>
+        <DescriptionListDescription>
+          {getDateTime(instance.updated_at)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Cloud provider</DescriptionListTerm>
+        <DescriptionListDescription>
+          {cloudProviderValueToLabel(instance.cloud_provider)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Region</DescriptionListTerm>
+        <DescriptionListDescription>
+          {regionValueToLabel(instance.region)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Sensor Host URL</DescriptionListTerm>
+        <DescriptionListDescription>-</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Central UI</DescriptionListTerm>
+        <DescriptionListDescription>{instance.host}</DescriptionListDescription>
+      </DescriptionListGroup>
+    </DescriptionList>
+  );
+}
+
+export default InstanceDetailsList;

--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -82,7 +82,7 @@ function InstanceDetailsPage() {
                       <Button
                         variant={ButtonVariant.primary}
                         component="a"
-                        href={`https://${instance.uiHost}`}
+                        href={`https://${instance.centralUIURL}`}
                         target="_blank"
                       >
                         Open ACS Console

--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -13,7 +13,6 @@ import {
   ButtonVariant,
   Card,
   CardHeader,
-  CardFooter,
   CardTitle,
   CardBody,
   CardHeaderMain,
@@ -27,11 +26,10 @@ import {
   PageSectionVariants,
   Spinner,
   Title,
-  Text,
-  TextContent,
 } from '@patternfly/react-core';
 import BreadcrumbItemLink from '../../components/BreadcrumbItemLink';
 import useInstance from '../../hooks/apis/useInstance';
+import InstanceDetailsList from '../../components/InstanceDetailsList';
 
 function InstanceDetailsPage() {
   const { instanceId } = useParams();
@@ -64,26 +62,49 @@ function InstanceDetailsPage() {
       </PageHeader>
       <Main className="pf-u-p-0 pf-m-fill pf-m-overflow-scroll">
         <PageSection>
-          <Card>
-            <CardHeader>
-              <CardHeaderMain>
-                <CardTitle>ACS Instance Access</CardTitle>
-              </CardHeaderMain>
-            </CardHeader>
-            <CardBody>
-              <p>Get started by signing in to your ACS instance.</p>
-            </CardBody>
-            <CardFooter>
-              <Button
-                variant={ButtonVariant.primary}
-                component="a"
-                href={`https://${instance.host}`}
-                target="_blank"
-              >
-                Sign in to ACS Instance
-              </Button>
-            </CardFooter>
-          </Card>
+          <Flex alignItems={{ default: 'alignItemsStretch' }}>
+            <FlexItem
+              flex={{ default: 'flex_1' }}
+              alignSelf={{ default: 'alignSelfStretch' }}
+            >
+              <Card className="pf-u-h-100">
+                <CardHeader>
+                  <CardHeaderMain>
+                    <CardTitle>ACS Instance Access</CardTitle>
+                  </CardHeaderMain>
+                </CardHeader>
+                <CardBody>
+                  <Flex direction={{ default: 'column' }}>
+                    <FlexItem>
+                      Get started by signing in to your ACS instance.
+                    </FlexItem>
+                    <FlexItem>
+                      <Button
+                        variant={ButtonVariant.primary}
+                        component="a"
+                        href={`https://${instance.uiHost}`}
+                        target="_blank"
+                      >
+                        Open ACS Console
+                      </Button>
+                    </FlexItem>
+                  </Flex>
+                </CardBody>
+              </Card>
+            </FlexItem>
+            <FlexItem flex={{ default: 'flex_1' }}>
+              <Card>
+                <CardHeader>
+                  <CardHeaderMain>
+                    <CardTitle>Instance Details</CardTitle>
+                  </CardHeaderMain>
+                </CardHeader>
+                <CardBody>
+                  <InstanceDetailsList instance={instance} />
+                </CardBody>
+              </Card>
+            </FlexItem>
+          </Flex>
         </PageSection>
         <PageSection
           variant={PageSectionVariants.light}
@@ -107,13 +128,29 @@ function InstanceDetailsPage() {
               </Card>
             </GridItem>
             <GridItem md={5} hasGutter>
-              <TextContent>
-                <Text>In this video, you’ll learn how to:</Text>
-              </TextContent>
-              <List>
-                <ListItem>Lorem ipsum dolor sit amet</ListItem>
-                <ListItem>You go back, Jack, do it again</ListItem>
-                <ListItem>Three is the magic number</ListItem>
+              <List isPlain>
+                <ListItem>
+                  <Button
+                    variant="link"
+                    isInline
+                    component="a"
+                    href="https://www.redhat.com/sysadmin/kubernetes-RHACS-red-hat-advanced-cluster-security"
+                    target="_blank"
+                  >
+                    Getting Started Guide
+                  </Button>
+                </ListItem>
+                <ListItem>
+                  <Button
+                    variant="link"
+                    isInline
+                    component="a"
+                    href="https://docs.openshift.com/acs/3.71/welcome/index.html"
+                    target="_blank"
+                  >
+                    Product Configuration
+                  </Button>
+                </ListItem>
               </List>
             </GridItem>
           </Grid>

--- a/src/routes/InstancesPage/InstanceDetailsDrawer.js
+++ b/src/routes/InstancesPage/InstanceDetailsDrawer.js
@@ -1,9 +1,5 @@
 /* eslint-disable react/prop-types */
 import {
-  DescriptionList,
-  DescriptionListDescription,
-  DescriptionListGroup,
-  DescriptionListTerm,
   Divider,
   Drawer,
   DrawerActions,
@@ -18,9 +14,7 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 
-import { getDateTime } from '../../utils/date';
-import { cloudProviderValueToLabel } from '../../utils/cloudProvider';
-import { regionValueToLabel } from '../../utils/region';
+import InstanceDetailsList from '../../components/InstanceDetailsList';
 
 function InstanceDetailsDrawer({ isExpanded, onClose, instance, children }) {
   return (
@@ -43,46 +37,7 @@ function InstanceDetailsDrawer({ isExpanded, onClose, instance, children }) {
             </DrawerHead>
             <Divider component="div" />
             <DrawerContentBody>
-              {instance && (
-                <DescriptionList isHorizontal>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>ID</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {instance.id}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Owner</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {instance.owner}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Time created</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {getDateTime(instance.created_at)}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Time updated</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {getDateTime(instance.updated_at)}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Cloud provider</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {cloudProviderValueToLabel(instance.cloud_provider)}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Region</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {regionValueToLabel(instance.region)}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                </DescriptionList>
-              )}
+              {instance && <InstanceDetailsList instance={instance} />}
             </DrawerContentBody>
           </DrawerPanelContent>
         }


### PR DESCRIPTION
### Description

This PR changes the details page by doing the following:
1. Adding the instance details information
2. Adding a link to the Getting Started Guide
3. Adding a link to the Product Configuration 

<img width="1552" alt="Screen Shot 2022-08-26 at 1 12 56 PM" src="https://user-images.githubusercontent.com/4805485/186983831-e9c626ba-aef4-48f3-a637-c7cfe05ec6e5.png">
<img width="1552" alt="Screen Shot 2022-08-26 at 1 12 58 PM" src="https://user-images.githubusercontent.com/4805485/186983840-0b129cd9-65a1-480c-882e-8038b4e060e4.png">


Mocks: https://www.sketch.com/s/caf22e03-37ae-459f-a32d-f10e3f9c728b/a/My245Y3