### PR TITLE
fix: disable interactions when instance is not ready

### DIFF
--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -224,14 +224,26 @@ function InstancesPage() {
                   <Tr
                     key={instance.name}
                     onRowClick={(event) => {
-                      if (event.target.getAttribute('type') !== 'button') {
+                      if (
+                        event.target.getAttribute('type') !== 'button' &&
+                        instance.status === 'ready'
+                      ) {
                         setViewingInstance(instance);
                       }
                     }}
                     isRowSelected={viewingInstance?.name === instance?.name}
                   >
                     <Td dataLabel="Name">
-                      <Link to={instanceDetailsURL}>{instance.name}</Link>
+                      <Button
+                        variant="link"
+                        isInline
+                        isDisabled={instance.status !== 'ready'}
+                        component={(props) => (
+                          <Link {...props} to={instanceDetailsURL} />
+                        )}
+                      >
+                        {instance.name}
+                      </Button>
                     </Td>
                     <Td dataLabel="Cloud provider">
                       {cloudProviderValueToLabel(instance.cloud_provider)}
@@ -247,24 +259,26 @@ function InstancesPage() {
                       {getDateTimeDifference(instance.created_at)}
                     </Td>
                     <Td isActionCell>
-                      <ActionsColumn
-                        items={[
-                          {
-                            title: 'Details',
-                            onClick: (event) => {
-                              event.preventDefault();
-                              history.push(instanceDetailsURL);
+                      {instance.status === 'ready' && (
+                        <ActionsColumn
+                          items={[
+                            {
+                              title: 'Details',
+                              onClick: (event) => {
+                                event.preventDefault();
+                                history.push(instanceDetailsURL);
+                              },
                             },
-                          },
-                          {
-                            title: 'Delete',
-                            onClick: (event) => {
-                              event.preventDefault();
-                              setDeletingInstance(instance);
+                            {
+                              title: 'Delete',
+                              onClick: (event) => {
+                                event.preventDefault();
+                                setDeletingInstance(instance);
+                              },
                             },
-                          },
-                        ]}
-                      />
+                          ]}
+                        />
+                      )}
                     </Td>
                   </Tr>
                 );


### PR DESCRIPTION
### Description

As the title suggests, this PR will disable interactions on the table row when the instance is not ready:
1. Name link will be disabled
2. Clicking the row won't open the drawer
3. The table row actions won't show up

### Screenshots

#### Creating
<img width="1552" alt="Screen Shot 2022-08-26 at 1 23 31 PM" src="https://user-images.githubusercontent.com/4805485/186985543-537f89f8-8955-4800-9125-806ac1428a13.png">

#### Ready
<img width="1552" alt="Screen Shot 2022-08-26 at 1 24 26 PM" src="https://user-images.githubusercontent.com/4805485/186985548-ecfe0760-e09b-45b5-9ef3-3d77963f12bc.png">

#### Deprovisioning
<img width="1552" alt="Screen Shot 2022-08-26 at 1 24 33 PM" src="https://user-images.githubusercontent.com/4805485/186985552-8900b1cb-90c1-4e36-b779-faac42f31d2f.png">

#### Deleting
<img width="1552" alt="Screen Shot 2022-08-26 at 1 24 53 PM" src="https://user-images.githubusercontent.com/4805485/186985555-9b7a973a-c77a-472e-96b6-eaa7ede2fdb6.png">
