### PR TITLE
feat: added 10 second polling for the list of central instances

### DIFF
--- a/src/hooks/apis/useInstances.js
+++ b/src/hooks/apis/useInstances.js
@@ -12,5 +12,8 @@ const getInstances = async ({ query }) => {
 };
 
 export default function useInstances(options) {
-  return useQuery(['instances', options], () => getInstances(options));
+  const { refetchInterval } = options;
+  return useQuery(['instances', options], () => getInstances(options), {
+    refetchInterval,
+  });
 }

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -84,6 +84,8 @@ function InstancesPage() {
       orderBy: `${sortOption.field} ${sortOption.direction}`,
       search: filtersToSearchQuery(filters),
     },
+    // Refetch the data every 10 seconds
+    refetchInterval: 10000,
   });
   const createInstance = useCreateInstance();
   const deleteInstance = useDeleteInstance();


### PR DESCRIPTION
### Description

This PR adds the ability to poll for the central instances every 10 seconds. Now you don't need to refresh the page to see the updated data

### Video

Try creating a central instance and deleting one to see the table update automagically. It takes a bit of time so sit back and relax