### PR TITLE
fix: backend added the URL scheme to the central UI URL so we shall adjust

### DIFF
--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -82,7 +82,7 @@ function InstanceDetailsPage() {
                       <Button
                         variant={ButtonVariant.primary}
                         component="a"
-                        href={`https://${instance.centralUIURL}`}
+                        href={instance.centralUIURL}
                         target="_blank"
                       >
                         Open ACS Console


### PR DESCRIPTION
### Description

The backend team now sends the URL scheme (`https://`) through the `centralUIURL` field so we don't need to add it ourselves