### PR TITLE
fix: distinguishing between the prod and stage openshift API

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -14,4 +14,11 @@ if (process.env.NODE_ENV === 'production') {
   );
 }
 
+// We want to access a PROD env variable within the UI code
+plugins.push(
+  new webpack.DefinePlugin({
+    'process.env.PROD': process.env.NODE_ENV === 'production',
+  })
+);
+
 module.exports = plugins;

--- a/src/services/apiRequest.js
+++ b/src/services/apiRequest.js
@@ -1,11 +1,14 @@
 import axios from 'axios';
 
+const API_URL = process.env.PROD
+  ? 'https://api.openshift.com'
+  : 'https://api.stage.openshift.com';
+
 export const authInterceptor = (client) => {
   client.interceptors.request.use(async (cfg) => {
     await insights.chrome.auth.getUser();
     const token = await insights.chrome.auth.getToken();
-    // @TODO: Allow flexibility of using staging environment vs. prod environment
-    const BASE_URL = cfg.baseURL || 'https://api.stage.openshift.com';
+    const BASE_URL = cfg.baseURL || API_URL;
     const updatedCfg = { ...cfg, url: `${BASE_URL}${cfg.url}` };
     if (token) {
       updatedCfg.headers = {


### PR DESCRIPTION
### Description

We want to be able to utilize the api.openshift.com endpoint within a production environment vs. the api.stage.openshift.com endpoint within a staging environment. The following PR changes make that possible by adding an additional webpack plugin that exposes an environment variable called `PROD` that we can use within our `apiRequest` module