### PR TITLE
feat: separating prod from staging

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Prod
 on: [push]
 jobs:
   build:
@@ -15,11 +15,11 @@ jobs:
       - name: Test
         run: npm test --passWithNoTests
       - name: Build
-        run: npm run build --if-present
+        run: npm run build:prod --if-present
       # store the build files into the cache
       - name: Cache Build
         uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-prod
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -1,0 +1,25 @@
+name: Build Staging
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout the repository
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Test
+        run: npm test --passWithNoTests
+      - name: Build
+        run: npm run build:staging --if-present
+      # store the build files into the cache
+      - name: Cache Build
+        uses: actions/cache@v2
+        id: restore-build-staging
+        with:
+          path: ${{ github.workspace }}/dist/*
+          key: ${{ github.sha }}

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,7 +1,7 @@
 name: Deploy Main
 on:
   workflow_run:
-    workflows: ['Build']
+    workflows: ['Build Staging']
     branches: [main]
     types:
       - completed
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-staging
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-staging
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-staging
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}

--- a/.github/workflows/deploy-prod-beta.yml
+++ b/.github/workflows/deploy-prod-beta.yml
@@ -1,7 +1,7 @@
 name: Deploy Prod Beta
 on:
   workflow_run:
-    workflows: ['Build']
+    workflows: ['Build Prod']
     branches: [prod-beta]
     types:
       - completed
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-prod
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}

--- a/.github/workflows/deploy-prod-stable.yml
+++ b/.github/workflows/deploy-prod-stable.yml
@@ -1,7 +1,7 @@
 name: Deploy Prod Stable
 on:
   workflow_run:
-    workflows: ['Build']
+    workflows: ['Build Prod']
     branches: [prod-stable]
     types:
       - completed
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-prod
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -1,7 +1,7 @@
 name: Deploy Stable
 on:
   workflow_run:
-    workflows: ['Build']
+    workflows: ['Build Staging']
     branches: [stable]
     types:
       - completed
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-staging
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-staging
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       # restore the build files from cache
       - uses: actions/cache@v2
-        id: restore-build
+        id: restore-build-staging
         with:
           path: ${{ github.workspace }}/dist/*
           key: ${{ github.sha }}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "analyze": "NODE_ENV=production webpack --config config/prod.webpack.config.js --env analyze=true",
-    "build": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
-    "deploy": "npm-run-all build lint test",
+    "build:prod": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
+    "build:staging": "NODE_ENV=staging webpack --config config/prod.webpack.config.js",
+    "deploy": "npm-run-all build:prod lint test",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint config src",
     "lint:js:fix": "eslint config src --fix",
@@ -22,7 +23,7 @@
     "start:prod:beta": "NODE_OPTIONS='--max-http-header-size=100000' PROD=true BETA=true npm start",
     "start:mock-server": "NODE_OPTIONS='--max-http-header-size=100000' node mocks/db.server.js",
     "test": "jest",
-    "verify": "npm-run-all build lint test"
+    "verify": "npm-run-all build:prod lint test"
   },
   "dependencies": {
     "@patternfly/react-core": "4.192.7",


### PR DESCRIPTION
### Description

The following changes in this PR should work with the changes I made in this PR https://github.com/RedHatInsights/acs-ui/pull/34 to so we can finally be able to utilize the api.openshift.com endpoint within a production environment vs. the api.stage.openshift.com endpoint within a staging environment. The changes I made were the following:

1. We separated the `build` command within package.json to `build:prod` and `build:staging` and we set the appropriate value for the `NODE_ENV` in each one
2. We will now have two separate build workflows (`Build Prod` and `Build Staging`) instead of just a `Build` workflow. Each of those will use the appropriate command mentioned in (1)
3. Each deploy-related workflow will now use the appropriate build workflow mentioned in (2)