### PR TITLE
feat: show table row actions even when not in ready state

### DIFF
--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -261,26 +261,24 @@ function InstancesPage() {
                       {getDateTimeDifference(instance.created_at)}
                     </Td>
                     <Td isActionCell>
-                      {instance.status === 'ready' && (
-                        <ActionsColumn
-                          items={[
-                            {
-                              title: 'Details',
-                              onClick: (event) => {
-                                event.preventDefault();
-                                history.push(instanceDetailsURL);
-                              },
+                      <ActionsColumn
+                        items={[
+                          {
+                            title: 'Details',
+                            onClick: (event) => {
+                              event.preventDefault();
+                              history.push(instanceDetailsURL);
                             },
-                            {
-                              title: 'Delete',
-                              onClick: (event) => {
-                                event.preventDefault();
-                                setDeletingInstance(instance);
-                              },
+                          },
+                          {
+                            title: 'Delete',
+                            onClick: (event) => {
+                              event.preventDefault();
+                              setDeletingInstance(instance);
                             },
-                          ]}
-                        />
-                      )}
+                          },
+                        ]}
+                      />
                     </Td>
                   </Tr>
                 );


### PR DESCRIPTION
## Description

This PR adds back the table row actions even when not in the ready state. Users may want to delete an instance if it's stuck in the creation phase

Reference: https://srox.slack.com/archives/C0313JYKH8W/p1663281667430639