### PR TITLE
feat: clear modal state before closing it

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -29,6 +29,14 @@ function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
   const [formValues, setFormValues] = useState(defaultFormValues);
   const [isRequestingCreate, setIsRequestingCreate] = useState(false);
 
+  function onCloseHandler() {
+    // clear all state before closing
+    setErrorMessage(null);
+    setFormValues(defaultFormValues);
+    setIsRequestingCreate(false);
+    onClose();
+  }
+
   function onChangeAvailabilityZones(isSelected, event) {
     const { id } = event.currentTarget;
     setFormValues((prevFormValues) => ({
@@ -69,7 +77,7 @@ function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
       variant={ModalVariant.small}
       title="Create ACS instance"
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={onCloseHandler}
       actions={[
         <Button
           key="createInstance"
@@ -83,7 +91,7 @@ function CreateInstanceModal({ isOpen, onClose, onRequestCreate }) {
         <Button
           key="cancel"
           variant="link"
-          onClick={onClose}
+          onClick={onCloseHandler}
           isDisabled={isRequestingCreate}
         >
           Cancel


### PR DESCRIPTION
### Description

This PR clears the error message state, resets the form field state, and clears the state we use to tell if a request was made whenever the modal is closed

### Screen Recording

https://user-images.githubusercontent.com/4805485/191346479-5a55ffc3-43bb-4508-91a6-e064898b38dc.mov


