### PR TITLE
ROX-12847: fix overview page copy

### DIFF
--- a/src/routes/OverviewPage/OverviewPage.js
+++ b/src/routes/OverviewPage/OverviewPage.js
@@ -36,7 +36,7 @@ function OverviewPage() {
             <Stack hasGutter>
               <TextContent>
                 <Text component={TextVariants.h1}>
-                  Get started with Red Hat Advanced Cluster Security Manages
+                  Get started with Red Hat Advanced Cluster Security Managed
                   Service for Kubernetes
                 </Text>
               </TextContent>


### PR DESCRIPTION
Fix a typo in the Overview Page header

![Screen Shot 2022-09-29 at 11 54 43 PM](https://user-images.githubusercontent.com/61400697/193193609-3b99e191-8eba-4c73-91a5-57f40e7c477f.png)
