### PR TITLE
fix: using production mode in staging environment

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,7 @@ const { config: webpackConfig, plugins } = config({
   appUrl: process.env.BETA
     ? '/beta/application-services/acs'
     : '/application-services/acs',
-  env: process.env.BETA ? 'stage-beta' : 'stage-stable',
+  env: process.env.BETA ? 'prod-beta' : 'prod-stable',
 });
 plugins.push(...commonPlugins);
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "nightly": "npm run deploy",
     "patch:hosts": "fec patch-etc-hosts",
     "start": "webpack serve --config config/dev.webpack.config.js",
-    "start:prod": "NODE_OPTIONS='--max-http-header-size=100000' PROD=true npm start",
     "start:beta": "NODE_OPTIONS='--max-http-header-size=100000' BETA=true npm start",
-    "start:prod:beta": "NODE_OPTIONS='--max-http-header-size=100000' PROD=true BETA=true npm start",
     "start:mock-server": "NODE_OPTIONS='--max-http-header-size=100000' node mocks/db.server.js",
     "test": "jest",
     "verify": "npm-run-all build:prod lint test"


### PR DESCRIPTION
### Description 

:warning: :warning: :warning: We migrated the stage fleet manager to use AMS as a quota backend. :warning: :warning: :warning:
As a result, requests must now come from [sso.redhat.com](http://sso.redhat.com/) accounts (e.g. the “normal” Red Hat account every employee has). At the same time, the UI has been moved to https://qaprodauth.cloud.redhat.com/application-services/acs/instances. Going forward, we must use the qaprodauth UI instead of the old [console.stage.redhat.com](http://console.stage.redhat.com/) UI. The latter still exists, but cannot create instances anymore. For the rationale behind the switch check out https://docs.google.com/document/d/12xq1ElAo6krniI-Yx_s8NB00Uzv1uQOKfH8IRxJpr08/edit?usp=sharing.

Because of the above changes, we need to run the UI in production mode when we develop locally. This PR does just that