### PR TITLE
ROX-12816: deleting instance with enter key

### DIFF
--- a/src/routes/InstancesPage/DeleteInstanceModal.js
+++ b/src/routes/InstancesPage/DeleteInstanceModal.js
@@ -35,7 +35,7 @@ function DeleteInstanceModal({ isOpen, instance, onRequestDelete, onClose }) {
   }
 
   function inputMatchesInstanceName() {
-    instance.name === inputValue;
+    return instance.name === inputValue;
   }
 
   if (!instance) return null;

--- a/src/routes/InstancesPage/DeleteInstanceModal.js
+++ b/src/routes/InstancesPage/DeleteInstanceModal.js
@@ -27,6 +27,17 @@ function DeleteInstanceModal({ isOpen, instance, onRequestDelete, onClose }) {
     }
   }
 
+  function deleteInstanceOnSubmit(e) {
+    e.preventDefault();
+    if (inputMatchesInstanceName()) {
+      onRequestDeleteHandler();
+    }
+  }
+
+  function inputMatchesInstanceName() {
+    instance.name === inputValue;
+  }
+
   if (!instance) return null;
 
   return (
@@ -41,7 +52,7 @@ function DeleteInstanceModal({ isOpen, instance, onRequestDelete, onClose }) {
           variant="danger"
           onClick={onRequestDeleteHandler}
           isLoading={isRequestingDelete}
-          isDisabled={isRequestingDelete || instance.name !== inputValue}
+          isDisabled={isRequestingDelete || !inputMatchesInstanceName()}
         >
           Delete instance
         </Button>,
@@ -62,7 +73,7 @@ function DeleteInstanceModal({ isOpen, instance, onRequestDelete, onClose }) {
         </div>
         <div>This action cannot be undone.</div>
       </div>
-      <Form>
+      <Form onSubmit={deleteInstanceOnSubmit}>
         <FormGroup
           label="Confirmation"
           isRequired


### PR DESCRIPTION
The delete modal currently refreshes the page and fails to delete the instance when a user hits enter on the input field. The expected behavior is the modal closes and the instance is deleted if the user hits enter.