### PR TITLE
ROX-12782: change sensor host url label

### DIFF
--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -49,7 +49,9 @@ function InstanceDetailsList({ instance }) {
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
-        <DescriptionListTerm>Sensor Host URL</DescriptionListTerm>
+        <DescriptionListTerm>
+          Central API Endpoint (include port)
+        </DescriptionListTerm>
         <DescriptionListDescription>
           {instance.centralDataURL}
         </DescriptionListDescription>

--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -49,9 +49,7 @@ function InstanceDetailsList({ instance }) {
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
-        <DescriptionListTerm>
-          Central API Endpoint (include port)
-        </DescriptionListTerm>
+        <DescriptionListTerm>Central API Endpoint</DescriptionListTerm>
         <DescriptionListDescription>
           {instance.centralDataURL}
         </DescriptionListDescription>


### PR DESCRIPTION
Update the label "Sensor Host URL" on the details page to "Central API Endpoint" to better align with the central cluster form