### PR TITLE
ROX-13007: deprecating staging environment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
+import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 
 import { Routes } from './Routes';
 import './App.scss';
@@ -21,7 +23,18 @@ const App = (props) => {
     };
   }, []);
 
-  return <Routes childProps={props} />;
+  const environment = insights.chrome.getEnvironment();
+
+  // We don't want to show the UI in the (unused) stage environment
+  if (environment === 'stage') {
+    return (
+      <Main>
+        <Unavailable />
+      </Main>
+    );
+  } else {
+    return <Routes childProps={props} />;
+  }
 };
 
 export default App;


### PR DESCRIPTION
## Description

Backend requested to prevent the use of the staging environment so this change will show an unavailable message in just that environment.

Reference to slack message: https://srox.slack.com/archives/C0313JYKH8W/p1665138184661119

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

No tests

```
# To run tests locally run:
npm run test
```