### PR TITLE
ROX-13382: reorder aws account number field in form and default select if only one available

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Alert,
   Button,
@@ -34,6 +34,16 @@ function CreateInstanceModal({
   const [errorMessage, setErrorMessage] = useState(null);
   const [formValues, setFormValues] = useState(defaultFormValues);
   const [isRequestingCreate, setIsRequestingCreate] = useState(false);
+
+  // default select a cloud account if there is only one available
+  // @TODO: Make a test for this
+  useEffect(() => {
+    if (formValues.aws_account_number === '' && cloudAccountIds.length === 1) {
+      setFormValues((prevValues) => {
+        return { ...prevValues, aws_account_number: cloudAccountIds[0] };
+      });
+    }
+  }, [cloudAccountIds]);
 
   function onCloseHandler() {
     // clear all state before closing
@@ -138,6 +148,28 @@ function CreateInstanceModal({
             isSelected={formValues.cloud_provider === 'aws'}
           />
         </FormGroup>
+        <FormGroup label="AWS account number" fieldId="aws_account_number">
+          <SelectSingle
+            id="aws_account_number"
+            value={formValues.aws_account_number}
+            handleSelect={onChangeAWSAccountNumber}
+            placeholderText={
+              cloudAccountIds.length === 0
+                ? 'No accounts available'
+                : 'Select an AWS Account'
+            }
+            menuAppendTo="parent"
+            isDisabled={cloudAccountIds.length === 0}
+          >
+            {cloudAccountIds.map((cloudAccountId) => {
+              return (
+                <SelectOption key={cloudAccountId} value={cloudAccountId}>
+                  {cloudAccountId}
+                </SelectOption>
+              );
+            })}
+          </SelectSingle>
+        </FormGroup>
         <FormGroup label="Cloud region" isRequired fieldId="region">
           <SelectSingle
             id="region"
@@ -173,28 +205,6 @@ function CreateInstanceModal({
               onChange={onChangeAvailabilityZones}
             />
           </ToggleGroup>
-        </FormGroup>
-        <FormGroup label="AWS account number" fieldId="aws_account_number">
-          <SelectSingle
-            id="aws_account_number"
-            value={formValues.aws_account_number}
-            handleSelect={onChangeAWSAccountNumber}
-            placeholderText={
-              cloudAccountIds.length === 0
-                ? 'No accounts available'
-                : 'Select an AWS Account'
-            }
-            menuAppendTo="parent"
-            isDisabled={cloudAccountIds.length === 0}
-          >
-            {cloudAccountIds.map((cloudAccountId) => {
-              return (
-                <SelectOption key={cloudAccountId} value={cloudAccountId}>
-                  {cloudAccountId}
-                </SelectOption>
-              );
-            })}
-          </SelectSingle>
         </FormGroup>
       </Form>
     </Modal>


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

This PR does the following:
* Place the AWS account selection directly below the Cloud Provider selection
* Auto-select the account if there is only one.

### Reordered fields ###
<img width="1552" alt="Screenshot 2022-11-02 at 10 23 12 AM" src="https://user-images.githubusercontent.com/4805485/199560510-75d39b4d-943f-4f14-8c2b-48aca189299e.png">

### When there is more than one option we don't default select ###
<img width="1552" alt="Screenshot 2022-11-02 at 10 31 45 AM" src="https://user-images.githubusercontent.com/4805485/199560765-9d5d487d-bc78-4d64-809f-da9ac2ee71fa.png">

### When there is only one option we do default select ###
<img width="1552" alt="Screenshot 2022-11-02 at 10 31 56 AM" src="https://user-images.githubusercontent.com/4805485/199560820-722a67ba-7e76-4f98-aefe-c4aa1e701b37.png">

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary~
- ~[ ] CI and all relevant tests are passing~
- ~[ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`~
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
npm run test
```