### PR TITLE
ROX-13604 + ROX-13626: changing aws_account_number to cloud_account_id and fixing youtube link

### DIFF
--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -119,7 +119,7 @@ function InstanceDetailsPage() {
             <GridItem md={7}>
               <Card className="marketing-video">
                 <iframe
-                  src="https://www.youtube.com/embed/wMJMFIeVsw8"
+                  src="https://www.youtube.com/embed/lFBFW3HmgsA"
                   title="Advanced Cluster Security in 2 Minutes"
                   frameBorder="0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -22,7 +22,7 @@ const defaultFormValues = {
   cloud_provider: 'aws',
   region: 'us-east-1',
   availabilityZones: 'multi',
-  aws_account_number: '',
+  cloud_account_id: '',
 };
 
 function CreateInstanceModal({
@@ -38,9 +38,9 @@ function CreateInstanceModal({
   // default select a cloud account if there is only one available
   // @TODO: Make a test for this
   useEffect(() => {
-    if (formValues.aws_account_number === '' && cloudAccountIds.length === 1) {
+    if (formValues.cloud_account_id === '' && cloudAccountIds.length === 1) {
       setFormValues((prevValues) => {
-        return { ...prevValues, aws_account_number: cloudAccountIds[0] };
+        return { ...prevValues, cloud_account_id: cloudAccountIds[0] };
       });
     }
   }, [cloudAccountIds]);
@@ -84,7 +84,7 @@ function CreateInstanceModal({
   function onChangeAWSAccountNumber(id, selection) {
     setFormValues((prevFormValues) => ({
       ...prevFormValues,
-      aws_account_number: selection,
+      cloud_account_id: selection,
     }));
   }
 
@@ -148,10 +148,10 @@ function CreateInstanceModal({
             isSelected={formValues.cloud_provider === 'aws'}
           />
         </FormGroup>
-        <FormGroup label="AWS account number" fieldId="aws_account_number">
+        <FormGroup label="AWS account number" fieldId="cloud_account_id">
           <SelectSingle
-            id="aws_account_number"
-            value={formValues.aws_account_number}
+            id="cloud_account_id"
+            value={formValues.cloud_account_id}
             handleSelect={onChangeAWSAccountNumber}
             placeholderText={
               cloudAccountIds.length === 0

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -116,7 +116,7 @@ function InstancesPage() {
       cloud_provider: values.cloud_provider,
       name: values.name,
       multi_az: values.availabilityZones === 'multi',
-      aws_account_number: values.aws_account_number,
+      cloud_account_id: values.cloud_account_id,
     });
     return response.catch((error) => {
       return error;


### PR DESCRIPTION
## Description

This is a simple text change to use `cloud_account_id` instead of `aws_account_number`. Seems like there might have been a mistake or a miscommunication on the field text name.

I also fixed the youtube link

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- ~[ ] Unit and integration tests added~
- ~[ ] Added test description under `Test manual`~
- ~[ ] Documentation added if necessary~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- ~[ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.~

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
npm run test
```