### PR TITLE
Rename endpoints in instance detail view

### DIFF
--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -49,13 +49,15 @@ function InstanceDetailsList({ instance }) {
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
-        <DescriptionListTerm>Central API Endpoint</DescriptionListTerm>
+        <DescriptionListTerm>
+          Central API endpoint (Sensor mTLS)
+        </DescriptionListTerm>
         <DescriptionListDescription>
           {instance.centralDataURL}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
-        <DescriptionListTerm>Central UI</DescriptionListTerm>
+        <DescriptionListTerm>Central instance (UI, roxctl)</DescriptionListTerm>
         <DescriptionListDescription>
           {instance.centralUIURL}
         </DescriptionListDescription>


### PR DESCRIPTION
## Description
Changing based on discussion in Slack thread, https://srox.slack.com/archives/C0313JYKH8W/p1670342527923849?thread_ts=1670341865.204039&cid=C0313JYKH8W

> rename entries in the cloud.r.c UI for clarity. Proposal:
> "Central API Endpoint" -> "Central API endpoint (Sensor mTLS)"
> "Central UI" -> "Central instance (UI, roxctl)"


## Checklist (Definition of Done)
- [ ] CI and all relevant tests are passing


## Test manual

Text change only.

Example:
<img width="1546" alt="Screen Shot 2022-12-07 at 9 19 28 AM" src="https://user-images.githubusercontent.com/715729/206204433-2cc2c951-3265-4c21-90ce-557f0cfa4ab7.png">
