### PR TITLE
ROX-13745: Fix pagination total in Instances list

### DIFF
--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -95,6 +95,7 @@ function InstancesPage() {
     // Refetch the data every 10 seconds
     refetchInterval: 10000,
   });
+
   const createInstance = useCreateInstance();
   const deleteInstance = useDeleteInstance();
   const [creatingInstance, setCreatingInstance] = useState(null);
@@ -103,6 +104,7 @@ function InstancesPage() {
 
   const instances = data?.items || [];
   const isTableLoading = isFetching && !data;
+  const totalInstances = data?.total ?? 0;
 
   let content = null;
 
@@ -181,7 +183,7 @@ function InstancesPage() {
                 align={{ default: 'alignRight' }}
               >
                 <Pagination
-                  itemCount={instances.length}
+                  itemCount={totalInstances}
                   perPage={perPage}
                   page={page}
                   onSetPage={onSetPage}
@@ -310,11 +312,11 @@ function InstancesPage() {
                 align={{ default: 'alignRight' }}
               >
                 <Pagination
-                  itemCount={instances.length}
+                  itemCount={totalInstances}
                   perPage={perPage}
                   page={page}
                   onSetPage={onSetPage}
-                  widgetId="acs-instances-top-pagination"
+                  widgetId="acs-instances-bottom-pagination"
                   onPerPageSelect={onPerPageSelect}
                 />
               </ToolbarItem>


### PR DESCRIPTION
## Description

Before this change, we were accidentally using the length of the current API call as the total for the pagination components. This was never more than the selected per-page length, so it was impossible to navigation to other pages when there was more than one page worth of results available.

The total count for a query on the `/centrals` endpoint is already available as a property in the `data` object, so I simply used that.

```
{
  "kind": "CentralRequestList",
  "page": 2,
  "size": 20,
  "total": 22,
  "items": [
    {
      "id": "ce7r92prdkj677csj2kg",
      ...
```

## Checklist (Definition of Done)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`


## Test manual

Correct top pagination:
<img width="1109" alt="Screen Shot 2022-12-07 at 10 21 18 AM" src="https://user-images.githubusercontent.com/715729/206221641-d2bc3d00-8875-40fc-b912-8c4d61bc9262.png">

Correct bottom pagination
<img width="1104" alt="Screen Shot 2022-12-07 at 10 21 38 AM" src="https://user-images.githubusercontent.com/715729/206221683-02d15879-bd6d-4e0f-a0b3-9ea4bed1fbf6.png">

Correct page 2
<img width="1120" alt="Screen Shot 2022-12-07 at 10 21 49 AM" src="https://user-images.githubusercontent.com/715729/206221701-9cc91f7c-2f51-4ea1-a871-498d1247786a.png">
