### PR TITLE
ROX-13227: Make "Open ACS Console" button disabled until the instance becomes ready

### DIFF
--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -51,13 +51,13 @@ function InstanceDetailsList({ instance }) {
       <DescriptionListGroup>
         <DescriptionListTerm>Central API Endpoint</DescriptionListTerm>
         <DescriptionListDescription>
-          {instance.centralDataURL}
+          {instance.centralDataURL || '-'}
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Central UI</DescriptionListTerm>
         <DescriptionListDescription>
-          {instance.centralUIURL}
+          {instance.centralUIURL || '-'}
         </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>

--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -83,6 +83,7 @@ function InstanceDetailsPage() {
                         variant={ButtonVariant.primary}
                         component="a"
                         href={instance.centralUIURL}
+                        isDisabled={!instance.centralUIURL}
                         target="_blank"
                       >
                         Open ACS Console


### PR DESCRIPTION
## Description
To prevent the "Negative DNS caching" issue - situation when user accesses Central URL before being ready and failed response is cached in the DNS, now we're not exposing the URLs until Central become ready.

I made a few changes in the UI to show more clearly that we're unable to access the instance when it's provisioning. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] ~Unit and integration tests added~
- [x] Added test description under `Test manual`
- [x] ~Documentation added if necessary~
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Local dev testing