### PR TITLE
ROX-13465: Surface error message when delete instance fails

### DIFF
--- a/src/routes/InstancesPage/DeleteInstanceModal.js
+++ b/src/routes/InstancesPage/DeleteInstanceModal.js
@@ -1,5 +1,7 @@
 /* eslint-disable react/prop-types */
 import {
+  Alert,
+  AlertVariant,
   Button,
   Form,
   FormGroup,
@@ -14,13 +16,18 @@ import React, { useState } from 'react';
 function DeleteInstanceModal({ isOpen, instance, onRequestDelete, onClose }) {
   const [inputValue, setInputValue] = useState('');
   const [isRequestingDelete, setIsRequestingDelete] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
   async function onRequestDeleteHandler() {
     setIsRequestingDelete(true);
+    setErrorMessage('');
     const result = await onRequestDelete(instance.id);
     setIsRequestingDelete(false);
-    if (result.error) {
-      // Do something
+    if (result.isAxiosError) {
+      setErrorMessage(
+        result.message ||
+          'An unanticapted error occurred. Please try again. If this error persists, please contact support.'
+      );
     } else {
       setInputValue('');
       onClose();
@@ -94,6 +101,9 @@ function DeleteInstanceModal({ isOpen, instance, onRequestDelete, onClose }) {
             to confirm.
           </HelperTextItem>
         </HelperText>
+        {errorMessage.length > 0 && (
+          <Alert isInline variant={AlertVariant.danger} title={errorMessage} />
+        )}
       </Form>
     </Modal>
   );


### PR DESCRIPTION
## Description

Simple UX enhancement

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Added test description under `Test manual`
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`

## Test manual

Tried to delete someone else's instance, and saw error message

<img width="1552" alt="Screen Shot 2022-12-15 at 10 33 21 AM" src="https://user-images.githubusercontent.com/715729/207902619-67d1e976-89d6-4bcb-b3da-75adeeadee01.png">
