### PR TITLE
ROX-15005: Hide aws account in case only one exists

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -148,19 +148,14 @@ function CreateInstanceModal({
             isSelected={formValues.cloud_provider === 'aws'}
           />
         </FormGroup>
-        {cloudAccountIds.length > 0 && (
+        {cloudAccountIds.length > 1 && (
           <FormGroup label="AWS account number" fieldId="cloud_account_id">
             <SelectSingle
               id="cloud_account_id"
               value={formValues.cloud_account_id}
               handleSelect={onChangeAWSAccountNumber}
-              placeholderText={
-                cloudAccountIds.length === 0
-                  ? 'No accounts available'
-                  : 'Select an AWS Account'
-              }
+              placeholderText="Select an AWS Account"
               menuAppendTo="parent"
-              isDisabled={cloudAccountIds.length === 0}
             >
               {cloudAccountIds.map((cloudAccountId) => {
                 return (


### PR DESCRIPTION
## Description
When only one account exists, we don't want to display the account selector field.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

with one account:
![Screenshot 2023-02-15 at 2 47 22 PM](https://user-images.githubusercontent.com/61400697/219155011-20f9a097-127c-49d2-9492-6c9f8f3e604e.png)



with multiple accounts:
![Screenshot 2023-02-15 at 2 50 35 PM](https://user-images.githubusercontent.com/61400697/219154986-ba513134-f34f-4add-8038-ebc9601c3514.png)


