### PR TITLE
ROX-14644: Change managed service text to cloud service

### DIFF
--- a/src/routes/OverviewPage/OverviewPage.js
+++ b/src/routes/OverviewPage/OverviewPage.js
@@ -36,8 +36,8 @@ function OverviewPage() {
             <Stack hasGutter>
               <TextContent>
                 <Text component={TextVariants.h1}>
-                  Get started with Red Hat Advanced Cluster Security Managed
-                  Service for Kubernetes
+                  Get started with Red Hat Advanced Cluster Security Cloud
+                  Service
                 </Text>
               </TextContent>
               <TextContent

--- a/src/routes/OverviewPage/OverviewPage.js
+++ b/src/routes/OverviewPage/OverviewPage.js
@@ -45,7 +45,7 @@ function OverviewPage() {
                 className="pf-u-color-200 pf-u-font-size-lg"
               >
                 <Text>
-                  Fully hosted and managed service for protecting cloud native
+                  Fully hosted cloud service for protecting cloud native
                   applications and Kubernetes
                 </Text>
               </TextContent>


### PR DESCRIPTION
## Description
Change text from `Managed Service` to `Cloud Service` and remove `Kubernetes` from the main header

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
Before: 
![Screenshot 2023-02-23 at 10 15 19 AM](https://user-images.githubusercontent.com/61400697/220966049-eb65b37d-74c2-41be-ac9d-cab24cb2171c.png)


After:
![Screenshot 2023-02-23 at 10 15 36 AM](https://user-images.githubusercontent.com/61400697/220966083-0ca727e9-69a8-49ae-b04f-08f5dc92f467.png)
