### PR TITLE
ROX-15884: Clarify cloud provider label in Instance

### DIFF
--- a/src/utils/cloudProvider.js
+++ b/src/utils/cloudProvider.js
@@ -2,6 +2,10 @@ const cloudProviders = {
   aws: 'Amazon Web Services',
 };
 
+const cloudProvidersShortForm = {
+  aws: 'AWS',
+};
+
 export const cloudProviderOptions = Object.keys(cloudProviders).map(
   (cloudProviderValue) => {
     return {
@@ -12,7 +16,9 @@ export const cloudProviderOptions = Object.keys(cloudProviders).map(
 );
 
 export function cloudProviderValueToLabel(cloudProviderValue) {
-  return cloudProviders[cloudProviderValue];
+  return cloudProvidersShortForm[cloudProviderValue]
+    ? `Hosted by Red Hat (on ${cloudProvidersShortForm[cloudProviderValue]})`
+    : 'Hosted by Red Hat';
 }
 
 export function cloudProviderLabelToValue(cloudProviderLabel) {

--- a/src/utils/cloudProvider.test.js
+++ b/src/utils/cloudProvider.test.js
@@ -1,0 +1,19 @@
+import { cloudProviderValueToLabel } from './cloudProvider';
+
+describe('cloudProvider', () => {
+  describe('cloudProviderValueToLabel', () => {
+    it('should return a string containing a known cloud provider', () => {
+      const cloudProviderValue = 'aws';
+      const cloudProviderDisplayValue =
+        cloudProviderValueToLabel(cloudProviderValue);
+      expect(cloudProviderDisplayValue).toBe('Hosted by Red Hat (on AWS)');
+    });
+
+    it('should return a generic string if the cloud provider is unrecognized', () => {
+      const cloudProviderValue = 'fly-by-nigh-cheap-web-hosting';
+      const cloudProviderDisplayValue =
+        cloudProviderValueToLabel(cloudProviderValue);
+      expect(cloudProviderDisplayValue).toBe('Hosted by Red Hat');
+    });
+  });
+});


### PR DESCRIPTION
## Description
Clarify language in Cloud Provider column of ACS Instances table

Example:
Instead of "Amazon Web Services",  display "Hosted by Red Hat (on AWS)"


## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] Unit and integration tests added
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Screenshots
<img width="1674" alt="Screen Shot 2023-03-10 at 5 49 14 PM" src="https://user-images.githubusercontent.com/715729/224443837-9e97ec4e-0f82-4140-95ff-9679de6030b3.png">
<img width="1674" alt="Screen Shot 2023-03-10 at 5 49 19 PM" src="https://user-images.githubusercontent.com/715729/224443839-9d296cc8-2423-4961-962b-069b8f40dcab.png">
