### PR TITLE
Restore PROD env mapping via plugin

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack');
+
 module.exports = {
   appUrl: '/application-services/acs',
   debug: true,
@@ -10,7 +12,12 @@ module.exports = {
   /**
    * Add additional webpack plugins
    */
-  plugins: [],
+  plugins: [
+    // We want to access a PROD env variable within the UI code
+    new webpack.DefinePlugin({
+      'process.env.PROD': process?.env?.NODE_ENV === 'production',
+    })
+  ],
   _unstableHotReload: process.env.HOT === 'true',
   moduleFederation: {
     exclude: ['react-router-dom'],


### PR DESCRIPTION
## Description
https://github.com/RedHatInsights/acs-ui/pull/72 has apparently dropped a definition of the `PROD` env var that tells ACS console UI plugin to talk to the prod fleet manager instance instead of the default stage one.

This PR attempts to restore previous behavior in the new, appropriate location.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] ~Unit and integration tests added~
- [ ] Added test description under `Test manual`
- [ ] ~Documentation added if necessary~
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [x] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
npm run test
```