### PR TITLE
Add protected routes using entitlement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { Reducer } from 'redux';
 
 import { Routes } from './Routes';
 import './App.scss';
+import AppContext, { defaultState } from './context/AppContext';
 
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
@@ -11,11 +12,34 @@ import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome'
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 
 const App = () => {
-  const { updateDocumentTitle, getEnvironment } = useChrome();
+  const { updateDocumentTitle, getEnvironment, auth } = useChrome();
+  const [isEntitled, setIsEntitled] = useState(defaultState.isEntitled);
+  const [isEntitlementLoaded, setIsEntitlementLoaded] = useState(
+    defaultState.isEntitlementLoaded
+  );
+
+  // by default entitlement will be disabled in development, use this flag to flip it on
+  const enableEntitlementLocally = false;
+
+  const isDevelopment = process.env.NODE_ENV === 'development';
 
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
+    const fetchEntitlements = async () => {
+      const user = await auth.getUser();
+      if (user !== undefined && (!isDevelopment || enableEntitlementLocally)) {
+        setIsEntitled(user.entitlements.acs.is_entitled);
+        setIsEntitlementLoaded(true);
+      }
+    };
+
+    fetchEntitlements();
+
+    // because local development is pointed to prod, the useChrome hook sets isProd to true, which consequently
+    // points analytics and entitlements to prod as well. These variables are used to override those issues locally
+    if (isDevelopment) {
       localStorage.setItem('chrome:analytics:dev', 'true');
+      setIsEntitled(true);
+      setIsEntitlementLoaded(true);
     }
 
     const registry = getRegistry();
@@ -31,8 +55,10 @@ const App = () => {
   } else {
     return (
       <Fragment>
-        <NotificationsPortal />
-        <Routes />
+        <AppContext.Provider value={{ isEntitled, isEntitlementLoaded }}>
+          <NotificationsPortal />
+          <Routes />
+        </AppContext.Provider>
       </Fragment>
     );
   }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,0 +1,18 @@
+import { Navigate } from 'react-router-dom';
+import React, { useContext } from 'react';
+
+import AppContext from './context/AppContext';
+import { linkBasename, mergeToBasename } from './utils/paths';
+
+const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
+  const { isEntitled, isEntitlementLoaded } = useContext(AppContext);
+  if (!isEntitlementLoaded) {
+    return <></>;
+  } else if (isEntitled) {
+    return children;
+  } else {
+    return <Navigate to={mergeToBasename('/overview', linkBasename)} replace />;
+  }
+};
+
+export default ProtectedRoute;

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes as RouterRoutes } from 'react-router-dom';
 import { linkBasename, mergeToBasename } from './utils/paths';
+import ProtectedRoute from './ProtectedRoute';
 
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
@@ -39,31 +40,51 @@ const GettingStartedPage = lazy(
     )
 );
 
-export const Routes = () => (
-  <Suspense
-    fallback={
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
-    }
-  >
-    <RouterRoutes>
-      <Route path="no-permissions" element={<NoPermissionsPage />} />
-      <Route path="oops" element={<OopsPage />} />
-      <Route
-        path="/instances/instance/:instanceId"
-        element={<InstanceDetailsPage />}
-      />
-      <Route path="/instances" element={<InstancesPage />} />
-      <Route path="/overview" element={<OverviewPage />} />
-      <Route path="/getting-started" element={<GettingStartedPage />} />
-      {/* Finally, catch all unmatched routes */}
-      <Route
-        path="*"
-        element={
-          <Navigate to={mergeToBasename('/overview', linkBasename)} replace />
-        }
-      />
-    </RouterRoutes>
-  </Suspense>
-);
+export const Routes = () => {
+  return (
+    <Suspense
+      fallback={
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      }
+    >
+      <RouterRoutes>
+        <Route path="no-permissions" element={<NoPermissionsPage />} />
+        <Route path="oops" element={<OopsPage />} />
+        <Route
+          path="/instances/instance/:instanceId"
+          element={
+            <ProtectedRoute>
+              <InstanceDetailsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/instances"
+          element={
+            <ProtectedRoute>
+              <InstancesPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/overview" element={<OverviewPage />} />
+        <Route
+          path="/getting-started"
+          element={
+            <ProtectedRoute>
+              <GettingStartedPage />
+            </ProtectedRoute>
+          }
+        />
+        {/* Finally, catch all unmatched routes */}
+        <Route
+          path="*"
+          element={
+            <Navigate to={mergeToBasename('/overview', linkBasename)} replace />
+          }
+        />
+      </RouterRoutes>
+    </Suspense>
+  );
+};

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export const defaultState = {
+  isEntitled: false,
+  isEntitlementLoaded: false,
+};
+
+export const AppContext = createContext(defaultState);
+export default AppContext;

--- a/src/routes/OverviewPage/OverviewPage.js
+++ b/src/routes/OverviewPage/OverviewPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   Button,
   ButtonVariant,
@@ -27,8 +27,10 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import AppLink from '../../components/AppLink';
 
 import bannerImage from '../../assets/banner_image.png';
+import AppContext from '../../context/AppContext';
 
 function OverviewPage() {
+  const { isEntitled } = useContext(AppContext);
   return (
     <div>
       <PageSection variant={PageSectionVariants.light} className="pf-u-p-2xl">
@@ -78,15 +80,17 @@ function OverviewPage() {
               </GridItem>
             </Grid>
           </FlexItem>
-          <FlexItem>
-            <Button
-              component={(props) => (
-                <AppLink {...props} to={'getting-started'} />
-              )}
-            >
-              Get Started
-            </Button>
-          </FlexItem>
+          {isEntitled && (
+            <FlexItem>
+              <Button
+                component={(props) => (
+                  <AppLink {...props} to={'getting-started'} />
+                )}
+              >
+                Get Started
+              </Button>
+            </FlexItem>
+          )}
         </Flex>
       </PageSection>
       <PageSection>


### PR DESCRIPTION
## Description
Prevent the user from visiting gating routes using entitlement.

Check the entitlement flag using the `useChrome` `auth` property. Set up a way to flip entitlement on and off easily when developing locally.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

When a user is not entitled, the `Get Started` button should not be visible on the Overview Page and all other pages aside from the Overview Page should redirect back to the Overview Page.

Entitlement can be turned on and off using the `enableEntitlementLocally` flag