### PR TITLE
Fix routes adding a double slash

### DIFF
--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -11,7 +11,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
   } else if (isEntitled) {
     return children;
   } else {
-    return <Navigate to={mergeToBasename('/overview', linkBasename)} replace />;
+    return <Navigate to={mergeToBasename('overview', linkBasename)} replace />;
   }
 };
 

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -81,7 +81,7 @@ export const Routes = () => {
         <Route
           path="*"
           element={
-            <Navigate to={mergeToBasename('/overview', linkBasename)} replace />
+            <Navigate to={mergeToBasename('overview', linkBasename)} replace />
           }
         />
       </RouterRoutes>

--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -261,7 +261,7 @@ function InstancesPage() {
               instances.length !== 0 &&
               instances.map((instance) => {
                 const instanceDetailsURL = mergeToBasename(
-                  `/instances/instance/${instance.id}`,
+                  `instances/instance/${instance.id}`,
                   linkBasename
                 );
                 return (


### PR DESCRIPTION
## Description
the `mergeToBasename` function handles the slash

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Used for the following links:

- Clicking an individual instance from the ACS Instances page
- Redirect to overview page when route not recognized
- Redirect to protected route