### PR TITLE
ROX-17475: Handle instance not found error

### DIFF
--- a/src/components/NotFoundMessage.tsx
+++ b/src/components/NotFoundMessage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/';
+import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateProps,
+  EmptyStateVariant,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+
+import AppLink from './AppLink';
+
+export interface NotFoundMessageProps
+  extends Omit<EmptyStateProps, 'children'> {
+  errorTitle?: string;
+  errorDescription?: React.ReactNode;
+  url: string;
+  actionText: string;
+}
+
+const NotFoundMessage: React.FunctionComponent<NotFoundMessageProps> = ({
+  errorTitle,
+  errorDescription,
+  url,
+  actionText,
+  ...props
+}) => {
+  return (
+    <EmptyState variant={EmptyStateVariant.large} {...props}>
+      <EmptyStateIcon icon={ExclamationCircleIcon} color={dangerColor.value} />
+      <Title headingLevel="h4" size="lg">
+        {errorTitle}
+      </Title>
+      <EmptyStateBody>
+        <Stack>
+          <StackItem>{errorDescription}</StackItem>
+        </Stack>
+      </EmptyStateBody>
+      <Button component={(props) => <AppLink {...props} to={url} />}>
+        {actionText}
+      </Button>
+    </EmptyState>
+  );
+};
+
+export default NotFoundMessage;

--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -50,7 +50,7 @@ function InstanceDetailsPage() {
       <NotFoundMessage
         errorTitle="Instance Not Found"
         actionText="Go to ACS Instances page"
-        errorDescription="It may have changed, did not exist, or no longer exists. Try using the ACS Instances page to find what you're looking for."
+        errorDescription="The URL may be incorrect, you may not have permission to view that instance, or that instance no longer exists. Try using the ACS Instances page to find what you are looking for."
         url="instances"
       />
     );

--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -31,15 +31,28 @@ import BreadcrumbItemLink from '../../components/BreadcrumbItemLink';
 import useInstance from '../../hooks/apis/useInstance';
 import InstanceDetailsList from '../../components/InstanceDetailsList';
 
+import NotFoundMessage from '../../components/NotFoundMessage';
+
 function InstanceDetailsPage() {
   const { instanceId } = useParams();
-  const { data: instance, isFetching } = useInstance(instanceId);
+  const { data: instance, isFetching, isError } = useInstance(instanceId);
 
   if (isFetching) {
     return (
       <Bullseye>
         <Spinner />
       </Bullseye>
+    );
+  }
+
+  if (isError) {
+    return (
+      <NotFoundMessage
+        errorTitle="Instance Not Found"
+        actionText="Go to ACS Instances page"
+        errorDescription="It may have changed, did not exist, or no longer exists. Try using the ACS Instances page to find what you're looking for."
+        url="instances"
+      />
     );
   }
 


### PR DESCRIPTION
## Description
When trying to access a non-existent instance (i.e. `/instances/instance/xxx`), the UI experiences a crash and displays a Sentry error. This can occur due to either the instance being deleted or an incorrect URL being entered. The former scenario can happen when clicking on an instance through `https://console.redhat.com/beta/application-services/subscriptions/rhacs`

We need to create a standard Not Found component to use in situations like this.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual
<img width="1675" alt="Screenshot 2023-06-01 at 1 54 47 AM" src="https://github.com/RedHatInsights/acs-ui/assets/61400697/a33f888a-8ee5-4a74-9530-0b15a5095055">
