### PR TITLE
Create temporary entitlement for newly subscribed user

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { Reducer } from 'redux';
+import { useSearchParams } from 'react-router-dom';
 
 import { Routes } from './Routes';
 import './App.scss';
@@ -11,8 +12,11 @@ import { notificationsReducer } from '@redhat-cloud-services/frontend-components
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 
+const LOCAL_STORAGE_ENTITLEMENT_KEY = 'acs_entitlement';
+
 const App = () => {
   const { updateDocumentTitle, getEnvironment, auth } = useChrome();
+  const [searchParams] = useSearchParams();
   const [isEntitled, setIsEntitled] = useState(defaultState.isEntitled);
   const [isEntitlementLoaded, setIsEntitlementLoaded] = useState(
     defaultState.isEntitlementLoaded
@@ -24,6 +28,27 @@ const App = () => {
   const isDevelopment = process.env.NODE_ENV === 'development';
 
   useEffect(() => {
+    const registry = getRegistry();
+    registry.register({ notifications: notificationsReducer as Reducer });
+
+    updateDocumentTitle('acs');
+  }, []);
+
+  useEffect(() => {
+    const setTemporaryLocalStorage = (
+      key: string,
+      value: string,
+      expirationTimeInHours: number
+    ) => {
+      const expirationTimestamp =
+        Date.now() + expirationTimeInHours * 60 * 60 * 1000;
+      const temporaryData = {
+        value,
+        expiresAt: expirationTimestamp,
+      };
+      localStorage.setItem(key, JSON.stringify(temporaryData));
+    };
+
     const fetchEntitlements = async () => {
       const user = await auth.getUser();
       if (user !== undefined && (!isDevelopment || enableEntitlementLocally)) {
@@ -32,21 +57,42 @@ const App = () => {
       }
     };
 
-    fetchEntitlements();
+    const handleEntitlement = () => {
+      const temporaryEntitlementString = localStorage.getItem(
+        LOCAL_STORAGE_ENTITLEMENT_KEY
+      );
+      if (temporaryEntitlementString) {
+        const temporaryEntitlementData = JSON.parse(temporaryEntitlementString);
+        if (temporaryEntitlementData.expiresAt <= Date.now()) {
+          localStorage.removeItem(LOCAL_STORAGE_ENTITLEMENT_KEY);
+          fetchEntitlements();
+        } else if (temporaryEntitlementData.value === 'true') {
+          setIsEntitled(true);
+          setIsEntitlementLoaded(true);
+        }
+      } else {
+        fetchEntitlements();
+      }
+    };
 
     // because local development is pointed to prod, the useChrome hook sets isProd to true, which consequently
     // points analytics and entitlements to prod as well. These variables are used to override those issues locally
-    if (isDevelopment) {
-      localStorage.setItem('chrome:analytics:dev', 'true');
-      setIsEntitled(true);
-      setIsEntitlementLoaded(true);
+    const handleDevelopmentEnvironment = () => {
+      if (isDevelopment) {
+        localStorage.setItem('chrome:analytics:dev', 'true');
+        setIsEntitled(true);
+        setIsEntitlementLoaded(true);
+      }
+    };
+
+    const isFromAws = searchParams.get('from-aws');
+    if (isFromAws) {
+      setTemporaryLocalStorage(LOCAL_STORAGE_ENTITLEMENT_KEY, 'true', 24);
     }
 
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer as Reducer });
-
-    updateDocumentTitle('acs');
-  }, []);
+    handleEntitlement();
+    handleDevelopmentEnvironment();
+  }, [searchParams]);
 
   const environment = getEnvironment();
 


### PR DESCRIPTION
## Description
Entitlements are updated every 30min, so a user may subscribe to ACS but not have immediate access for up to 30min. A workaround is creating a temporary entitlement key in local storage. This key can will override the entitlement value obtained from user info. The local storage key will expire after 24 hours and will be automatically deleted. Once deleted, entitlement data should accurately reflect the user's access.

It's important to note that even when creating an instance, we still perform a check for an active subscription.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Visit the site without entitlement —> add query parameter to url `?from-aws=true` —> user should be able to access routes as if entitled —> revisit site after expired date has passed —> user considered not entitled again