### PR TITLE
ROX-17945: Remove free tier line from Overview page

### DIFF
--- a/src/routes/OverviewPage/OverviewPage.js
+++ b/src/routes/OverviewPage/OverviewPage.js
@@ -225,12 +225,6 @@ function OverviewPage() {
                 <FlexItem>
                   <DescriptionList isHorizontal>
                     <DescriptionListGroup>
-                      <DescriptionListTerm>First 20 vCPU</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        Free
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
                       <DescriptionListTerm>Managed vCPU</DescriptionListTerm>
                       <DescriptionListDescription>
                         $0.03 / hour


### PR DESCRIPTION
## Description
No free tier at all for now.
 
We will add a link to the trial later.

## Checklist (Definition of Done)
- [ ] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`

## Test manual

Before this change:
![Screen Shot 2023-06-20 at 8 52 43 AM](https://github.com/RedHatInsights/acs-ui/assets/715729/d1176420-557a-4fc4-b2ab-bc1e422a4dfc)

After this change:
<img width="530" alt="Screen Shot 2023-06-20 at 9 20 28 AM" src="https://github.com/RedHatInsights/acs-ui/assets/715729/b3a48309-c330-4732-b819-530a562afad9">
