### PR TITLE
ROX-17945: Remove free tier line from Overview page (#99)

### DIFF
--- a/src/routes/OverviewPage/OverviewPage.js
+++ b/src/routes/OverviewPage/OverviewPage.js
@@ -225,12 +225,6 @@ function OverviewPage() {
                 <FlexItem>
                   <DescriptionList isHorizontal>
                     <DescriptionListGroup>
-                      <DescriptionListTerm>First 20 vCPU</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        Free
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
                       <DescriptionListTerm>Managed vCPU</DescriptionListTerm>
                       <DescriptionListDescription>
                         $0.03 / hour


### PR DESCRIPTION
Remove "Free Tier" language from qaprodauth "production" version