### PR TITLE
ROX-18074: Adding label text and disabling the dropdown when there is no AWS acct

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -50,7 +50,9 @@ function CreateInstanceModal({
   }, [cloudAccountIds]);
 
   const { data: cloudRegionList, isFetching: isFetchingRegions } =
-    useCloudRegions({ provider: AWS_PROVIDER });
+    useCloudRegions({
+      provider: AWS_PROVIDER,
+    });
   const cloudRegions = useMemo(
     () => cloudRegionList?.items || [],
     [cloudRegionList]
@@ -164,25 +166,32 @@ function CreateInstanceModal({
             isSelected={formValues.cloud_provider === AWS_PROVIDER}
           />
         </FormGroup>
-        {cloudAccountIds.length > 1 && (
-          <FormGroup label="AWS account number" fieldId="cloud_account_id">
-            <SelectSingle
-              id="cloud_account_id"
-              value={formValues.cloud_account_id}
-              handleSelect={onChangeAWSAccountNumber}
-              placeholderText="Select an AWS Account"
-              menuAppendTo="parent"
-            >
-              {cloudAccountIds.map((cloudAccountId) => {
-                return (
-                  <SelectOption key={cloudAccountId} value={cloudAccountId}>
-                    {cloudAccountId}
-                  </SelectOption>
-                );
-              })}
-            </SelectSingle>
-          </FormGroup>
-        )}
+        <FormGroup
+          label="AWS account number"
+          labelInfo={
+            cloudAccountIds.length === 0
+              ? 'This will be attributed to your Red Hat subscription'
+              : undefined
+          }
+          fieldId="cloud_account_id"
+        >
+          <SelectSingle
+            id="cloud_account_id"
+            value={formValues.cloud_account_id}
+            handleSelect={onChangeAWSAccountNumber}
+            placeholderText="Select an AWS Account"
+            menuAppendTo="parent"
+            isDisabled={cloudAccountIds.length === 0}
+          >
+            {cloudAccountIds.map((cloudAccountId) => {
+              return (
+                <SelectOption key={cloudAccountId} value={cloudAccountId}>
+                  {cloudAccountId}
+                </SelectOption>
+              );
+            })}
+          </SelectSingle>
+        </FormGroup>
         <FormGroup label="Cloud region" isRequired fieldId="region">
           <SelectSingle
             id="region"

--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -168,9 +168,9 @@ function CreateInstanceModal({
         </FormGroup>
         <FormGroup
           label="AWS account number"
-          labelInfo={
+          helperText={
             cloudAccountIds.length === 0
-              ? 'This will be attributed to your Red Hat subscription'
+              ? 'This will be attributed to your Red Hat subscription.'
               : undefined
           }
           fieldId="cloud_account_id"


### PR DESCRIPTION

<img width="570" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/b1ed0ddc-db0f-4514-b910-7615f115f52b">


Everything else should remain the same -- when there are no AWS accounts, the dropdown should be disabled and the additional label text should show as above.