### PR TITLE
ROX-18075: Disabling AWS dropdown when there is only one account

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -113,7 +113,7 @@ function CreateInstanceModal({
     }));
   }
 
-  function getAWSLabelInfoText() {
+  function getAWSHelperText() {
     if (cloudAccountIds.length === 0) {
       return 'This will be attributed to your Red Hat subscription.';
     }
@@ -178,7 +178,7 @@ function CreateInstanceModal({
         </FormGroup>
         <FormGroup
           label="AWS account number"
-          labelInfo={getAWSLabelInfoText()}
+          helperText={getAWSHelperText()}
           fieldId="cloud_account_id"
         >
           <SelectSingle

--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -113,6 +113,16 @@ function CreateInstanceModal({
     }));
   }
 
+  function getAWSLabelInfoText() {
+    if (cloudAccountIds.length === 0) {
+      return 'This will be attributed to your Red Hat subscription.';
+    }
+    if (cloudAccountIds.length === 1) {
+      return 'The AWS account indicated, which is linked to your Red Hat organization, will be used for billing purposes.';
+    }
+    return undefined;
+  }
+
   return (
     <Modal
       variant={ModalVariant.small}
@@ -168,11 +178,7 @@ function CreateInstanceModal({
         </FormGroup>
         <FormGroup
           label="AWS account number"
-          helperText={
-            cloudAccountIds.length === 0
-              ? 'This will be attributed to your Red Hat subscription.'
-              : undefined
-          }
+          labelInfo={getAWSLabelInfoText()}
           fieldId="cloud_account_id"
         >
           <SelectSingle
@@ -181,7 +187,7 @@ function CreateInstanceModal({
             handleSelect={onChangeAWSAccountNumber}
             placeholderText="Select an AWS Account"
             menuAppendTo="parent"
-            isDisabled={cloudAccountIds.length === 0}
+            isDisabled={cloudAccountIds.length <= 1}
           >
             {cloudAccountIds.map((cloudAccountId) => {
               return (


### PR DESCRIPTION
As stated. The AWS dropdown is disabled when there is only one account and the helper text reads "The AWS account indicated, which is linked to your Red Hat organization, will be used for billing purposes." The behavior should still stay consistently disabled w associated helper text when there are no accounts available.
<img width="570" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/6294c013-7132-4967-8a0c-e6887e06291e">
