### PR TITLE
ROX-18076: Making AWS dropdown required when more than one acct

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -120,7 +120,17 @@ function CreateInstanceModal({
     if (cloudAccountIds.length === 1) {
       return 'The AWS account indicated, which is linked to your Red Hat organization, will be used for billing purposes.';
     }
+    if (cloudAccountIds.length > 1) {
+      return 'Please select one of the AWS accounts for billing purposes.';
+    }
     return undefined;
+  }
+
+  function isInvalidForm() {
+    return (
+      !formValues?.name ||
+      (cloudAccountIds.length > 1 && !formValues?.cloud_account_id)
+    );
   }
 
   return (
@@ -135,7 +145,7 @@ function CreateInstanceModal({
           variant="primary"
           onClick={onRequestCreateHandler}
           isLoading={isRequestingCreate}
-          isDisabled={isRequestingCreate || !formValues?.name}
+          isDisabled={isRequestingCreate || isInvalidForm()}
         >
           Create instance
         </Button>,
@@ -179,6 +189,7 @@ function CreateInstanceModal({
         <FormGroup
           label="AWS account number"
           helperText={getAWSHelperText()}
+          isRequired={cloudAccountIds.length > 1}
           fieldId="cloud_account_id"
         >
           <SelectSingle


### PR DESCRIPTION
As it states above. The `next` button should be disabled upon load even with the name filled out until the user has selected an AWS account number from the dropdown. The dropdown should still be disabled as expected when there are one or no AWS accounts found.

<img width="591" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/be68b6d5-2423-4df7-9912-d11588fcbc92">
<img width="571" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/a7d50daf-dc3d-409a-9548-4e5233a671a6">
