### PR TITLE
ROX-16513: Making instance details copyable

### DIFF
--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -30,7 +30,11 @@ function InstanceDetailsList({ instance }) {
       <DescriptionListGroup>
         <DescriptionListTerm>ID</DescriptionListTerm>
         <DescriptionListDescription>
-          <ClipboardCopy hoverTip="Copy" clickTip="Copied">
+          <ClipboardCopy
+            hoverTip="Copy"
+            clickTip="Copied"
+            variant="inline-compact"
+          >
             {instance.id}
           </ClipboardCopy>
         </DescriptionListDescription>
@@ -58,7 +62,11 @@ function InstanceDetailsList({ instance }) {
           Central API endpoint (Sensor mTLS)
         </DescriptionListTerm>
         <DescriptionListDescription>
-          <ClipboardCopy hoverTip="Copy" clickTip="Copied">
+          <ClipboardCopy
+            hoverTip="Copy"
+            clickTip="Copied"
+            variant="inline-compact"
+          >
             {instance.centralDataURL || '-'}
           </ClipboardCopy>
         </DescriptionListDescription>
@@ -66,7 +74,11 @@ function InstanceDetailsList({ instance }) {
       <DescriptionListGroup>
         <DescriptionListTerm>Central instance (UI, roxctl)</DescriptionListTerm>
         <DescriptionListDescription>
-          <ClipboardCopy hoverTip="Copy" clickTip="Copied">
+          <ClipboardCopy
+            hoverTip="Copy"
+            clickTip="Copied"
+            variant="inline-compact"
+          >
             {instance.centralUIURL || '-'}
           </ClipboardCopy>
         </DescriptionListDescription>

--- a/src/components/InstanceDetailsList.js
+++ b/src/components/InstanceDetailsList.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import {
+  ClipboardCopy,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -28,7 +29,11 @@ function InstanceDetailsList({ instance }) {
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>ID</DescriptionListTerm>
-        <DescriptionListDescription>{instance.id}</DescriptionListDescription>
+        <DescriptionListDescription>
+          <ClipboardCopy hoverTip="Copy" clickTip="Copied">
+            {instance.id}
+          </ClipboardCopy>
+        </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Owner</DescriptionListTerm>
@@ -53,13 +58,17 @@ function InstanceDetailsList({ instance }) {
           Central API endpoint (Sensor mTLS)
         </DescriptionListTerm>
         <DescriptionListDescription>
-          {instance.centralDataURL || '-'}
+          <ClipboardCopy hoverTip="Copy" clickTip="Copied">
+            {instance.centralDataURL || '-'}
+          </ClipboardCopy>
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
         <DescriptionListTerm>Central instance (UI, roxctl)</DescriptionListTerm>
         <DescriptionListDescription>
-          {instance.centralUIURL || '-'}
+          <ClipboardCopy hoverTip="Copy" clickTip="Copied">
+            {instance.centralUIURL || '-'}
+          </ClipboardCopy>
         </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>


### PR DESCRIPTION
As the title states -- making ID, central API endpoint, and central instance details copyable via inline copy component in PatternFly. Should look like below:

<img width="1439" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/b8600407-e2b1-4d90-9719-09d1866c9c2c">
