### PR TITLE
ROX-18865: removing Cloud Provider and Availability Zone form groups from create instance modal

### DIFF
--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -9,9 +9,6 @@ import {
   ModalVariant,
   SelectOption,
   TextInput,
-  Tile,
-  ToggleGroup,
-  ToggleGroupItem,
 } from '@patternfly/react-core';
 
 import SelectSingle from '../../components/SelectSingle';
@@ -82,14 +79,6 @@ function CreateInstanceModal({
       setFormValues(defaultFormValues);
       onClose();
     }
-  }
-
-  function onChangeAvailabilityZones(isSelected, event) {
-    const { id } = event.currentTarget;
-    setFormValues((prevFormValues) => ({
-      ...prevFormValues,
-      availabilityZones: id,
-    }));
   }
 
   function onCloudRegionSelect(id, selection) {
@@ -180,12 +169,6 @@ function CreateInstanceModal({
             onChange={onNameChange}
           />
         </FormGroup>
-        <FormGroup label="Cloud provider" isRequired fieldId="cloud_provider">
-          <Tile
-            title="Amazon Web Services"
-            isSelected={formValues.cloud_provider === AWS_PROVIDER}
-          />
-        </FormGroup>
         <FormGroup
           label="AWS account number"
           helperText={getAWSHelperText()}
@@ -227,27 +210,6 @@ function CreateInstanceModal({
               );
             })}
           </SelectSingle>
-        </FormGroup>
-        <FormGroup
-          label="Availability zones"
-          isRequired
-          fieldId="availabilityZones"
-        >
-          <ToggleGroup aria-label="Availability Zones">
-            <ToggleGroupItem
-              text="Single"
-              buttonId="single"
-              isSelected={formValues.availabilityZones === 'single'}
-              onChange={onChangeAvailabilityZones}
-              isDisabled
-            />
-            <ToggleGroupItem
-              text="Multi"
-              buttonId="multi"
-              isSelected={formValues.availabilityZones === 'multi'}
-              onChange={onChangeAvailabilityZones}
-            />
-          </ToggleGroup>
         </FormGroup>
       </Form>
     </Modal>

--- a/src/routes/InstancesPage/CreateInstanceModal.js
+++ b/src/routes/InstancesPage/CreateInstanceModal.js
@@ -19,8 +19,10 @@ import { getRegionDisplayName } from '../../utils/region';
 
 const defaultFormValues = {
   name: '',
+  // this value is left out of the form because no other options are available to the user (ROX-18865)
   cloud_provider: AWS_PROVIDER,
   region: AWS_DEFAULT_REGION,
+  // this value is left out of the form because no other options are available to the user (ROX-18865)
   availabilityZones: 'multi',
   cloud_account_id: '',
 };


### PR DESCRIPTION
As it states in the title above. It should look as below:
<img width="577" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/23eec549-de1c-4ffd-ba3a-0aab008fffd1">
