### PR TITLE
ROX-18739: Fixed region filter bug

### DIFF
--- a/src/utils/region.js
+++ b/src/utils/region.js
@@ -1,7 +1,5 @@
 export function regionLabelToValue(regionLabel, regionList) {
-  const regionOption = regionList?.find((region) =>
-    getRegionDisplayName(region).startsWith(regionLabel)
-  );
+  const regionOption = regionList?.find((region) => region.id === regionLabel);
   return regionOption?.id;
 }
 

--- a/src/utils/searchQuery.test.js
+++ b/src/utils/searchQuery.test.js
@@ -18,7 +18,7 @@ describe('searchQuery', () => {
 
     it('should return the correct search query for the region category', () => {
       const filters = {
-        region: ['US-East, N. Virginia', 'Europe, Ireland'],
+        region: ['us-east-1', 'eu-west-1'],
       };
       const searchQuery = filtersToSearchQuery(filters, [
         {

--- a/src/utils/searchQuery.test.js
+++ b/src/utils/searchQuery.test.js
@@ -62,7 +62,7 @@ describe('searchQuery', () => {
     it('should return the correct search query for multiple categories', () => {
       const filters = {
         name: ['sc-test-1'],
-        region: ['US-East, N. Virginia'],
+        region: ['us-east-1'],
         owner: ['schaudhr'],
       };
       const searchQuery = filtersToSearchQuery(filters, [


### PR DESCRIPTION
Region filter was not working as expected for ACS Instances list (`undefined` was being passed through the API). It should filter properly now (should pass the region id now instead)

<img width="600" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/07a11999-1f16-438b-9191-d72187264187">
<img width="1139" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/3e690657-5f77-452f-8301-d04c00868760">
<img width="1153" alt="image" src="https://github.com/RedHatInsights/acs-ui/assets/10412893/72ec5289-e455-4c17-ba38-0e1b11a9f1c3">
