### PR TITLE
Adding integration server case when stage/preview

### DIFF
--- a/src/hooks/apis/useApi.js
+++ b/src/hooks/apis/useApi.js
@@ -4,10 +4,16 @@ import axios from 'axios';
 
 const API_PROD_URL = 'https://api.openshift.com';
 const API_STAGE_URL = 'https://api.stage.openshift.com';
+const API_INTEGRATION_URL = 'https://api.integration.openshift.com';
 
 export default function useApi() {
-  const { isProd } = useChrome();
-  const apiUrl = isProd() ? API_PROD_URL : API_STAGE_URL;
+  const { isProd, isBeta } = useChrome();
+  let apiUrl = API_STAGE_URL;
+  if (isProd()) {
+    apiUrl = API_PROD_URL;
+  } else if (isBeta()) {
+    apiUrl = API_INTEGRATION_URL;
+  }
   const authInterceptor = (client) => {
     client.interceptors.request.use(async (cfg) => {
       await insights.chrome.auth.getUser();


### PR DESCRIPTION
Added a case in the `useApi` hook to use the new `integration` endpoint when the UI is accessed on stage -> beta/preview as discussed.