### PR TITLE
ROX-19826: Bump Node to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "webpack-bundle-analyzer": "4.4.2"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=18.0.0",
         "npm": ">=7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": false,
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=18.0.0",
     "npm": ">=7.0.0"
   },
   "scripts": {


### PR DESCRIPTION
`rm -rf node_modules`
`npm i`
`npm run start` should run without issues

this is enabled due to stage/prod running on node 18 already https://redhat-internal.slack.com/archives/C023VGW21NU/p1695837441304849?thread_ts=1695834456.226359&cid=C023VGW21NU