### PR TITLE
Set `NODE_ENV` to production during image builds

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -11,6 +11,7 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build'
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
 export NODE_BUILD_VERSION=18
+export NODE_ENV="production"
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -11,6 +11,7 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build'
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
 export NODE_BUILD_VERSION=18
+export NODE_ENV="production"
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
## Description

Sets `process.env.NODE_ENV` to `"production"` during automated Jenkins builds. The UI depends on this value to configure analytics and disable verbose redux logging, and the containerized build process does not set it automatically.

Note: Other places in the UI seem to use the `const { isProd } = useChrome();` function/hook call for a similar purpose. Would it make sense to replace any usage of `process.env` with this call as well?

## Test manual

See the setting of this variable in the Jenkins [build output](https://ci.ext.devshift.net/job/RedHatInsights-acs-ui-pr-check/8/console):
```17:23:03 NODE_ENV=production```

Download the built image and inspect a file manually. We will look for the minified output and try to analyze this snippet from `useAnalytics.js`:
```js
  function analyticsTrack(event) {
    const isProdEnv = process.env.NODE_ENV === 'production';
    const isDevEnv = process.env.NODE_ENV === 'development';
    const analyticsDevKeySet =
      localStorage.getItem('chrome:analytics:dev') === 'true';

    if (isProdEnv || (isDevEnv && analyticsDevKeySet)) {
      analytics.track(event);
    }
  }
```

Find a file in the image with a string marker from the above function:
```sh
podman run -it  quay.io/cloudservices/acs-ui:pr-173-06e20e3   /bin/bash

[root@a17bb8490f2a src]# grep -irl "chrome:analytics:dev" dist/
dist/js/532.b6e6108d4b5a47258b2b.js
dist/js/InstancesPage.b6e6108d4b5a47258b2b.js
dist/js/exposed-./RootApp.b6e6108d4b5a47258b2b.js
dist/sourcemaps/532.6537879e94a59e317e74ec864053df14.js.map
dist/sourcemaps/InstancesPage.059707fe4c1c85046149e25a157dd0c5.js.map
dist/sourcemaps/exposed-./RootApp.2b9f3a87a709aa6b6d8b26066bfc5ad7.js.map
```

Copy the file out into local file system:
```sh
podman cp a17bb8490f2a:/opt/app-root/src/dist/js/InstancesPage.b6e6108d4b5a47258b2b.js .
```

Open the file in an editor and prettify, searching for the `"chrome:analytics:dev"` text:

```js
      const q = function () {
        var e = (0, z.Z)().analytics;
        return {
          analyticsTrack: function (t) {
            localStorage.getItem("chrome:analytics:dev"), e.track(t);
          },
        };
      };
```
