### PR TITLE
Enable Openshift basename

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ These are the urls for each branch:
 
 ### Beta
 
-* main -> <https://console.stage.redhat.com/preview/application-services/acs>
-* qa-beta -> <https://qaprodauth.console.redhat.com/preview/application-services/acs>
-* prod-beta -> <https://console.redhat.com/preview/application-services/acs>
+* main -> <https://console.stage.redhat.com/preview/application-services/acs> or <https://console.stage.redhat.com/preview/openshift/acs>
+* qa-beta -> <https://qaprodauth.console.redhat.com/preview/application-services/acs> or <https://qaprodauth.console.redhat.com/preview/openshift/acs>
+* prod-beta -> <https://console.redhat.com/preview/application-services/acs> or <https://console.redhat.com/preview/openshift/acs>
 
 ### Stable
 
-* stage-stable -> <https://console.stage.redhat.com/application-services/acs>
-* qa-stable -> <https://qaprodauth.console.redhat.com/application-services/acs>
-* prod-stable -> <https://console.redhat.com/application-services/acs>
+* stage-stable -> <https://console.stage.redhat.com/application-services/acs> or <https://console.stage.redhat.com/openshift/acs>
+* qa-stable -> <https://qaprodauth.console.redhat.com/application-services/acs> or <https://qaprodauth.console.redhat.com/openshift/acs>
+* prod-stable -> <https://console.redhat.com/application-services/acs> or <https://console.redhat.com/openshift/acs>

--- a/fec.config.js
+++ b/fec.config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 
 module.exports = {
-  appUrl: '/application-services/acs',
+  appUrl: ['/application-services/acs', '/openshift/acs'],
   debug: true,
   useProxy: true,
   proxyVerbose: true,
@@ -18,6 +18,16 @@ module.exports = {
       'process.env.PROD': process?.env?.NODE_ENV === 'production',
     }),
   ],
+  routes: {
+    ...(process.env.CONFIG_PORT && {
+      '/api/chrome-service/v1/static': {
+        host: `http://localhost:${process.env.CONFIG_PORT}`,
+      },
+      '/api/chrome-service/v1/dashboard-templates': {
+        host: `http://localhost:${process.env.CONFIG_PORT}`,
+      },
+    }),
+  },
   _unstableHotReload: process.env.HOT === 'true',
   moduleFederation: {
     exclude: ['react-router-dom'],

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -2,13 +2,21 @@ import { To } from 'react-router-dom';
 
 export const linkBasename = '/application-services/acs';
 export const mergeToBasename = (to: To, basename: string): To => {
+  const currBaseName =
+    location.pathname.includes('/openshift/') &&
+    basename.includes('/application-services/')
+      ? basename.replace('/application-services/', '/openshift/')
+      : basename;
   if (typeof to === 'string') {
     // replace possible "//" after basename
-    return `${basename}/${to}`.replace(`^${basename}//`, '/');
+    return `${currBaseName}/${to}`.replace(`^${currBaseName}//`, '/');
   }
 
   return {
     ...to,
-    pathname: `${basename}/${to.pathname}`.replace(`^${basename}//`, '/'),
+    pathname: `${currBaseName}/${to.pathname}`.replace(
+      `^${currBaseName}//`,
+      '/'
+    ),
   };
 };


### PR DESCRIPTION
## Description
As a preparation for moving ACS to Openshift bundle we have to adjust the app availability and basename. This PR addresses both of these things. With this PR ACS ui can operate on both application services and openshift bundle.

### JIRA

https://issues.redhat.com/browse/RHCLOUD-29707

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [-] Unit and integration tests added
- [-] Added test description under `Test manual`
- [x] Documentation added if necessary
- [x] CI and all relevant tests are passing
- [x] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [-] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.