### PR TITLE
ROX-27851: Fix functionality of ACS instance search UI

### DIFF
--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -166,7 +166,12 @@ function InstancesPage() {
     setFilters({});
   }
 
-  if (instances.length === 0 && Object.keys(filters).length === 0) {
+  const hasNoInstances =
+    instances.length === 0 &&
+    Object.keys(filters).length === 0 &&
+    !isTableLoading;
+
+  if (hasNoInstances) {
     content = (
       <EmptyState>
         <EmptyStateHeader
@@ -373,9 +378,7 @@ function InstancesPage() {
       <Main>
         <Card>{content}</Card>
         <CreateInstanceModal
-          isOpen={
-            !!creatingInstance || (instances.length === 0 && !isTableLoading)
-          }
+          isOpen={!!creatingInstance || hasNoInstances}
           onClose={closeCreateInstanceModal}
           onRequestCreate={onRequestCreate}
           cloudAccountIds={cloudAccountIds}

--- a/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
+++ b/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
@@ -91,7 +91,7 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
     if (!input) return;
 
     setFilters((prevFilters) => {
-      const newFilters = { ...prevFilters };
+      const newFilters = structuredClone(prevFilters);
       const fieldFilters = newFilters[field] ?? [];
       if (!fieldFilters.includes(input)) {
         newFilters[field] = [...fieldFilters, input];

--- a/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
+++ b/src/routes/InstancesPage/InstancesToolbarSearchFilter.js
@@ -87,6 +87,20 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
     onSelect('status', event, selection);
   }
 
+  function applyCurrentSearchText(field, input, setInput) {
+    if (!input) return;
+
+    setFilters((prevFilters) => {
+      const newFilters = { ...prevFilters };
+      const fieldFilters = newFilters[field] ?? [];
+      if (!fieldFilters.includes(input)) {
+        newFilters[field] = [...fieldFilters, input];
+      }
+      return newFilters;
+    });
+    setInput('');
+  }
+
   return (
     <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
       <ToolbarGroup variant="filter-group">
@@ -121,6 +135,11 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
                   placeholder="Filter by name"
                   value={inputName}
                   onChange={(_event, value) => setInputName(value)}
+                  onKeyPress={(event) => {
+                    if (event.key === 'Enter') {
+                      applyCurrentSearchText('name', inputName, setInputName);
+                    }
+                  }}
                 />
               </InputGroupItem>
               <InputGroupItem>
@@ -128,12 +147,7 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
                   variant="control"
                   aria-label="Search Name"
                   onClick={() => {
-                    if (!inputName) return;
-                    setFilters((prevFilters) => {
-                      const newFilters = { ...prevFilters };
-                      newFilters.name = [inputName];
-                      return newFilters;
-                    });
+                    applyCurrentSearchText('name', inputName, setInputName);
                   }}
                 >
                   <SearchIcon />
@@ -186,6 +200,15 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
                   placeholder="Filter by owner"
                   value={inputOwner}
                   onChange={(_event, value) => setInputOwner(value)}
+                  onKeyPress={(event) => {
+                    if (event.key === 'Enter') {
+                      applyCurrentSearchText(
+                        'owner',
+                        inputOwner,
+                        setInputOwner
+                      );
+                    }
+                  }}
                 />
               </InputGroupItem>
               <InputGroupItem>
@@ -193,12 +216,7 @@ function InstancesToolbarSearchFilter({ filters, setFilters }) {
                   variant="control"
                   aria-label="Search Owner"
                   onClick={() => {
-                    if (!inputOwner) return;
-                    setFilters((prevFilters) => {
-                      const newFilters = { ...prevFilters };
-                      newFilters.owner = [inputOwner];
-                      return newFilters;
-                    });
+                    applyCurrentSearchText('owner', inputOwner, setInputOwner);
                   }}
                 >
                   <SearchIcon />

--- a/src/utils/searchQuery.js
+++ b/src/utils/searchQuery.js
@@ -16,14 +16,22 @@ export function filtersToSearchQuery(filters, regionList) {
           .map((searchValue) => {
             // Use the value the API needs rather than the human readable UI value
             let modifiedSearchValue = searchValue;
+            let comparator = '=';
             if (searchCategory === 'cloud_provider') {
               modifiedSearchValue = cloudProviderLabelToValue(searchValue);
             } else if (searchCategory === 'region') {
               modifiedSearchValue = regionLabelToValue(searchValue, regionList);
             } else if (searchCategory === 'status') {
               modifiedSearchValue = statusLabelToValue(searchValue);
+            } else if (
+              searchCategory === 'name' ||
+              searchCategory === 'owner'
+            ) {
+              // 'name' and 'owner' fields should do a substring search instead of an exact match
+              modifiedSearchValue = `%25${searchValue}%25`;
+              comparator = 'LIKE';
             }
-            return `${searchCategory} = ${modifiedSearchValue}`;
+            return `${searchCategory} ${comparator} ${modifiedSearchValue}`;
           })
           .join(' or ');
         return `(${searchCategoryResult})`;

--- a/src/utils/searchQuery.test.js
+++ b/src/utils/searchQuery.test.js
@@ -13,7 +13,7 @@ describe('searchQuery', () => {
         name: ['sc-test-1'],
       };
       const searchQuery = filtersToSearchQuery(filters, []);
-      expect(searchQuery).toBe('(name = sc-test-1)');
+      expect(searchQuery).toBe('(name LIKE %25sc-test-1%25)');
     });
 
     it('should return the correct search query for the region category', () => {
@@ -38,7 +38,7 @@ describe('searchQuery', () => {
         owner: ['schaudhr'],
       };
       const searchQuery = filtersToSearchQuery(filters, []);
-      expect(searchQuery).toBe('(owner = schaudhr)');
+      expect(searchQuery).toBe('(owner LIKE %25schaudhr%25)');
     });
 
     it('should return the correct search query for the status category', () => {
@@ -72,7 +72,7 @@ describe('searchQuery', () => {
         },
       ]);
       expect(searchQuery).toBe(
-        '(name = sc-test-1) and (region = us-east-1) and (owner = schaudhr)'
+        '(name LIKE %25sc-test-1%25) and (region = us-east-1) and (owner LIKE %25schaudhr%25)'
       );
     });
 
@@ -82,7 +82,7 @@ describe('searchQuery', () => {
         owner: [],
       };
       const searchQuery = filtersToSearchQuery(filters, []);
-      expect(searchQuery).toBe('(name = sc-test-1)');
+      expect(searchQuery).toBe('(name LIKE %25sc-test-1%25)');
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes the following issues with the ACS instance search:

- Applying a search no longer opens the "Create instance" modal in a way that locks the page
- The "Enter" key can be used to apply a text search, adding the value to the filters and clearing the input box
- Multiple text searches of a single category can be added at once (e.g. name/owner)
- The search query sent to the API is fixed to allow _substring_ matches instead of exact matches. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Note that in the following tests, the rendering of some fields was overridden to redact the true values and replace text with `*` characters. Only the subset that matches an applied filter is not redacted in order to demonstrate that this works.

Visit "ACS Instances":

![image](https://github.com/user-attachments/assets/1aef79f1-6364-4f1c-a40b-180bd05ef6b4)

Apply a name filter by adding text and pressing "enter":
![image](https://github.com/user-attachments/assets/55b0f69e-f487-4170-b236-5603783bedd8)
![image](https://github.com/user-attachments/assets/c85005d5-804f-4437-8e4b-f310e6c72529)

Add additional name filters and also an owner filter using the same method:
![image](https://github.com/user-attachments/assets/1f4a03f2-ab02-49e3-8cfd-168e4d2e55fb)
![image](https://github.com/user-attachments/assets/6afbcc5c-f772-4476-9892-df1eeec97cfe)
