### PR TITLE
ROX-27850: Add spacing to table controls to avoid overlay button

### DIFF
--- a/src/routes/InstancesPage/InstancesPage.js
+++ b/src/routes/InstancesPage/InstancesPage.js
@@ -313,7 +313,7 @@ function InstancesPage() {
                     <Td dataLabel="Time created">
                       {getDateTimeDifference(instance.created_at)}
                     </Td>
-                    <Td isActionCell>
+                    <Td isActionCell className="pf-v5-u-pr-xl">
                       <ActionsColumn
                         items={[
                           {
@@ -344,6 +344,7 @@ function InstancesPage() {
               <ToolbarItem
                 variant="pagination"
                 align={{ default: 'alignRight' }}
+                className="pf-v5-u-mr-2xl"
               >
                 <Pagination
                   itemCount={totalInstances}


### PR DESCRIPTION
## Description

Adds a little bit of extra wiggle room to the bottom pagination and table row actions in order to avoid conflicting with the floating action button on the bottom right of the page.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

ACS Instances table with additional padding on the affected elements:
![image](https://github.com/user-attachments/assets/b4c1b4ea-a0c7-4b1f-9961-ff90c4b45708)


