### PR TITLE
ROX-26638: Fix helm install commands

### DIFF
--- a/src/routes/GettingStartedPage/Wizard/InstallWithHelm.js
+++ b/src/routes/GettingStartedPage/Wizard/InstallWithHelm.js
@@ -45,11 +45,12 @@ const InstallWithHelm = () => {
   };
 
   const codeBlock =
-    `helm install rhacs-secured-cluster-services rhacs/secured-cluster-services -n stackrox \\ \n` +
-    `-f <path_to_cluster_init_bundle.yaml> \\ \n` +
-    `--set clusterName=<name_of_the_secured_cluster> \\ \n` +
-    `--set centralEndpoint=<endpoint_of_central_service> \\ \n` +
-    `--set imagePullSecrets.username=<your redhat.com username> \\ \n` +
+    `helm install -n stackrox --create-namespace \\\n` +
+    `stackrox-secured-cluster-services rhacs/secured-cluster-services \\\n` +
+    `-f <path_to_cluster_init_bundle.yaml> \\\n` +
+    `--set clusterName=<name_of_the_secured_cluster> \\\n` +
+    `--set centralEndpoint=<endpoint_of_central_service> \\\n` +
+    `--set imagePullSecrets.username=<your redhat.com username> \\\n` +
     `--set imagePullSecrets.password=<your redhat.com password>`;
 
   const actions = (
@@ -166,13 +167,10 @@ const InstallWithHelm = () => {
             </ExpandableSection>
           </ListItem>
           <ListItem>
-            Run the following Helm install command:
-            <CodeBlock actions={actions} className="pf-v6-u-mt-sm">
-              <CodeBlockCode id="code-content">{codeBlock}</CodeBlockCode>
-            </CodeBlock>
             <div className="pf-v6-u-mt-sm">
               If this is the first time you’re using helm, you will need to add
-              the stackrox repo using the following commands:
+              the <span className="pf-v6-u-font-weight-bold">rhacs</span> repo
+              using the following commands:
             </div>
             <div className="pf-v6-u-mt-sm">
               <ClipboardCopy
@@ -182,7 +180,7 @@ const InstallWithHelm = () => {
                 isCode
                 className="pf-v6-u-my-sm"
               >
-                {`helm repo add stackrox https://mirror.openshift.com/pub/rhacs/charts`}
+                {`helm repo add rhacs https://mirror.openshift.com/pub/rhacs/charts`}
               </ClipboardCopy>
             </div>
             <div className="pf-v6-u-my-sm">
@@ -196,8 +194,12 @@ const InstallWithHelm = () => {
                 {`helm repo update`}
               </ClipboardCopy>
             </div>
+            Run the following Helm install command:
+            <CodeBlock actions={actions} className="pf-v6-u-mt-sm">
+              <CodeBlockCode id="code-content">{codeBlock}</CodeBlockCode>
+            </CodeBlock>
             <div>
-              For image pull secretes, there are better options for credentials
+              For image pull secrets, there are better options for credentials
               for registry.redhat.io, like a{' '}
               <Button
                 variant="link"


### PR DESCRIPTION
## Description

As titled, fixes `helm` installation documentation so that the commands work.

Also moves the section "If this is the first time you’re using helm, you will need to add the stackrox repo using the following commands" so that it is *before* the command that will error out if this step isn't completed.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Follow the instructions in the UI to set up an ACSCS instance, then secure an infra GKE cluster via this instance:
```
$ helm install -n stackrox --create-namespace \
stackrox-secured-cluster-services rhacs/secured-cluster-services \
-f /Users/dvail/Downloads/test-infra-cluster-Helm-values-cluster-init-bundle.yaml \
--set clusterName=dv-03-19-behind-change-nor \
--set centralEndpoint=acs-data-cvde5l1e4r9aim6ikat0.acs.rhcloud.com:443 \
--set imagePullSecrets.username='***********' \
--set imagePullSecrets.password='***********'
NAME: stackrox-secured-cluster-services
LAST DEPLOYED: Wed Mar 19 12:27:56 2025
NAMESPACE: stackrox
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
StackRox Secured Cluster Services 4.7.0 has been installed.


Secured Cluster Configuration Summary:

  Name:                                        dv-03-19-behind-change-nor
  Kubernetes Namespace:                        stackrox
  Helm Release Name:                           stackrox-secured-cluster-services
  Central Endpoint:                            acs-data-cvde5l1e4r9aim6ikat0.acs.rhcloud.com:443
  OpenShift Cluster:                           false
  Admission Control Webhooks deployed:
  Admission Control Creates/Updates enforced:  false
  Scanner V4:                                  disabled
  Bootstrapping Method:                        Init Bundle

Please take note of the following:

- PodSecurityPolicies are disabled, since your environment does not support them according to API
  server properties.

Thank you for using StackRox!
```

![image](https://github.com/user-attachments/assets/57fb5ad2-a8d9-47da-b888-4880ede21b05)
