### PR TITLE
ROX-13227: hide the central UI url if Central is not ready yet

### DIFF
--- a/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
+++ b/src/routes/InstanceDetailsPage/InstanceDetailsPage.js
@@ -23,12 +23,14 @@ import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner'
 import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 import useInstance from '../../hooks/apis/useInstance';
 import InstanceDetailsList from '../../components/InstanceDetailsList';
-
+import { statuses } from '../../utils/status';
 import NotFoundMessage from '../../components/NotFoundMessage';
 
 function InstanceDetailsPage() {
   const { instanceId } = useParams();
   const { data: instance, isFetching, isError } = useInstance(instanceId);
+  const isCentralReady = instance?.status === statuses.ready;
+  const shownCentralUIURL = isCentralReady ? instance.centralUIURL : null;
 
   if (isFetching) {
     return (
@@ -78,8 +80,8 @@ function InstanceDetailsPage() {
                       <Button
                         variant={ButtonVariant.primary}
                         component="a"
-                        href={instance.centralUIURL}
-                        isDisabled={!instance.centralUIURL}
+                        href={shownCentralUIURL}
+                        isDisabled={!shownCentralUIURL}
                         target="_blank"
                       >
                         Open ACS Console


### PR DESCRIPTION
## Description

If the user clicks on the link to show the Central instance page, and Central is not ready (e.g. routes are not created), then the user will see an error page and the browser will cache bad DNS entries, and might take a while to recover. 

This PR hides the Central UI url if the central is not ready. 

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

**TODO:** Add manual testing efforts

```
# To run tests locally run:
npm run test
```