### PR TITLE
Update frontend.yaml in support of the FEO migration

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -10,6 +10,53 @@ objects:
     metadata:
       name: acs
     spec:
+      feoConfigEnabled: true
+      navigationSegments:
+        # ACS Navigation is referenced as a foreign module with configuration similar to below
+        # TODO: Update this with a link comment to the parent navigation module's repo
+        # - segmentref:
+        #   frontendname: acs
+        #   segmentId: acs
+        - segmentId: acs
+          navItems:
+            - id: acs.nav
+              title: Advanced Cluster Security
+              expandable: true
+              routes:
+              - id: clusterOverview
+                product: acs
+                title: Overview
+                href: "/openshift/acs/overview"
+                icon: ACSIcon
+              - id: acsGettingStarted
+                product: acs
+                title: Getting Started
+                href: "/openshift/acs/getting-started"
+              - id: acsInstances
+                product: acs
+                title: ACS Instances
+                href: "/openshift/acs/instances"
+              - id: clustersDocumentation
+                title: Documentation
+                isExternal: true
+                href: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes
+      serviceTiles:
+        - section: security
+          group: openshift
+          id: acs
+          href: /openshift/acs/overview
+          title: Advanced Cluster Security
+          description: Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.
+          icon: ACSIcon
+      searchEntries:
+        - id: acs
+          title: Advanced Cluster Security
+          description: Securely build, deploy, and run your cloud applications using Kubernetes-native architecture.
+          href: /openshift/acs/overview
+          alt_title:
+            - acs
+            - ACS
+            - operators
       envName: ${ENV_NAME}
       title: ACS UI
       deploymentRepo: https://github.com/RedHatInsights/acs-ui
@@ -23,10 +70,10 @@ objects:
       module:
         manifestLocation: "/apps/acs/fed-mods.json"
         modules:
-          - id: "acs"
-            module: "./RootApp"
-            routes:
-              - pathname: /application-services/acs
+        - id: "acs"
+          module: "./RootApp"
+          routes:
+            - pathname: /openshift/acs
 parameters:
   - name: ENV_NAME
     required: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@babel/preset-typescript": "^7.17.12",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.4",
-        "@redhat-cloud-services/frontend-components-config": "^6.4.5",
+        "@redhat-cloud-services/frontend-components-config": "^6.6.9",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.16",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
@@ -2516,9 +2516,9 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-webpack/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3118,14 +3118,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.4.5.tgz",
-      "integrity": "sha512-soNkbbCij8J9Vw44S3vREt2Gt6PFQ4nHE9iLI+BzaCt7Psab1zSq/G7iDgXntVhLr6X2JtfPRZl8xZjuYJs5tA==",
+      "version": "6.6.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.6.11.tgz",
+      "integrity": "sha512-97IztUl8PdAUOI/KpCe/iZ/JvFJc/OOfC9b3qPNZ8uipAHRjx06AWDbE4S5TFXpQczZb2DbxA+4OS6xKmGnXMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^4.1.3",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^4.7.0",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
@@ -3172,9 +3172,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.1.4.tgz",
-      "integrity": "sha512-J0/4xPzEXtCxwvRQ5P20v/dGUjD7/I1ORr33gTSp/kK8bMHHz9rbzgUdJvNvWCZCA6KmgtV9g4yWISlSopbAcg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.7.0.tgz",
+      "integrity": "sha512-MUxsr2qS2x0ALFfgjRGGyTxMiwpzHeMYYZTOvK6TUQXAXTn98JkEo2qxQesZq8zGIGBTeyw5yb+/DQqxCwbpLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-typescript": "^7.17.12",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.4",
-    "@redhat-cloud-services/frontend-components-config": "^6.4.5",
+    "@redhat-cloud-services/frontend-components-config": "^6.6.9",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.16",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",


### PR DESCRIPTION
## Description

Frontend Operator migration as required by the crc-experiences team.

This moves configuration from the global https://github.com/RedHatInsights/chrome-service-backend repository into our app, allowing us to update navigation, service tiles, and search from within this repo.

See more context in the [migration guide](https://github.com/RedHatInsights/chrome-service-backend/blob/main/docs/feo-migration-guide.md), and a plan for how we make this live [on Slack](https://redhat-internal.slack.com/archives/C023VGW21NU/p1757694022226329).

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

None at the moment as this first step is not testable. For future testing steps, the following is the plan to complete the migration:

1. Merge our PR to the [RedHatInsights/acs-ui repo](https://github.com/RedHatInsights/acs-ui/pull/205/files) updating our frontend.yaml
2. Open and merge PRs against chrome-service-backend that add "feoReplacement": "acs.nav" to beta/staging and stable/staging in [this area](https://github.com/RedHatInsights/chrome-service-backend/blob/main/static/beta/stage/navigation/openshift-navigation.json#L200)
3. Open and merge PRs against the uhc-portal that replace the [acs navigation](https://github.com/RedHatInsights/uhc-portal/blob/main/deploy/frontend.yaml#L103) config with a segmentRef so that our team has ownership of the nested navigation like done for cost-management [here](https://github.com/RedHatInsights/uhc-portal/blob/main/deploy/frontend.yaml#L92)
4. Deploy a new build of our app to staging
    1. Test that the navigation looks good on [console.stage.redhat.com](http://console.stage.redhat.com/)
    2. Test that there are duplicate entries for ACS under the services dropdown, one from the new FEO config and one from [services.json](https://github.com/RedHatInsights/chrome-service-backend/blob/main/static/beta/stage/services/services.json#L475)
5. Open and merge PRs against chrome-service-backend that deletes our service dropdown entry for beta/staging and stable/staging from services.json
    1. Test that there is now only a single entry for ACS under the services dropdown
6. Repeat steps 2-5 for beta/prod and stable/prod and ensure everything continues to work as expected
7. Open a final PR against chrome-service-backend to delete our entry from [static-services-entries.json](https://github.com/RedHatInsights/chrome-service-backend/blob/main/cmd/search/static-services-entries.json#L123)