### PR TITLE
Revert capitalization change for FEO migration canary

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -34,7 +34,7 @@ objects:
                 href: "/openshift/acs/getting-started"
               - id: acsInstances
                 product: acs
-                title: ACS instances
+                title: ACS Instances
                 href: "/openshift/acs/instances"
               - id: clustersDocumentation
                 title: Documentation


### PR DESCRIPTION
## Description

Reverts https://github.com/RedHatInsights/acs-ui/pull/210

The FEO migration config was verified with the changed navigation capitalization. This reverts back to the original text.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] Unit and integration tests added
- [ ] Added test description under `Test manual`
- [ ] Documentation added if necessary
- [ ] CI and all relevant tests are passing
- [ ] Add the ticket number to the PR title if available, i.e. `ROX-12345: ...`
- [ ] Discussed security and business related topics privately. Will move any security and business related topics that arise to private communication channel.

## Test manual

Deploy and verifiy the navigation visually.
