### PR TITLE
Add widget registry config for widget-layout service

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -74,6 +74,17 @@ objects:
           module: "./RootApp"
           routes:
             - pathname: /openshift/acs
+      widgetRegistry:
+        - scope: "landing"
+          module: "./AcsWidget"
+          config:
+            title: "Advanced Cluster Security"
+            icon: "ACSIcon"
+          defaults:
+            w: 1
+            h: 4
+            maxH: 10
+            minH: 1
 parameters:
   - name: ENV_NAME
     required: true


### PR DESCRIPTION
## Summary
- Migrate ACS widget configuration from chrome service to `frontend.yaml` `widgetRegistry` format
- Omitted empty `headerLink: {}` as the CRD schema requires both `title` and `href`

Current widget conifigs in prod:

```json
{
    "scope": "landing",
    "module": "./AcsWidget",
    "defaults": {
        "w": 1,
        "h": 4,
        "maxH": 10,
        "minH": 1
    },
    "config": {
        "title": "Advanced Cluster Security",
        "icon": "ACSIcon",
        "headerLink": {}
    }
}
```

Jira Epic (Decouple widget dashboard backend from Chrome service): https://redhat.atlassian.net/browse/RHCLOUD-40474
